### PR TITLE
chore: map old env vars in legacy package

### DIFF
--- a/.changeset/dirty-phones-exist.md
+++ b/.changeset/dirty-phones-exist.md
@@ -1,0 +1,6 @@
+---
+"lingo.dev": minor
+"replexica": minor
+---
+
+map old env vars

--- a/action.yml
+++ b/action.yml
@@ -10,11 +10,11 @@ runs:
   using: "docker"
   image: "action/Dockerfile"
   env:
-    REPLEXICA_API_KEY: ${{ inputs.api-key }}
-    REPLEXICA_PULL_REQUEST: ${{ inputs.pull-request }}
-    REPLEXICA_COMMIT_MESSAGE: ${{ inputs.commit-message }}
-    REPLEXICA_PULL_REQUEST_TITLE: ${{ inputs.pull-request-title }}
-    REPLEXICA_WORKING_DIRECTORY: ${{ inputs.working-directory }}
+    LINGODOTDEV_API_KEY: ${{ inputs.api-key }}
+    LINGODOTDEV_PULL_REQUEST: ${{ inputs.pull-request }}
+    LINGODOTDEV_COMMIT_MESSAGE: ${{ inputs.commit-message }}
+    LINGODOTDEV_PULL_REQUEST_TITLE: ${{ inputs.pull-request-title }}
+    LINGODOTDEV_WORKING_DIRECTORY: ${{ inputs.working-directory }}
 
 inputs:
   api-key:

--- a/action/src/platforms/_base.ts
+++ b/action/src/platforms/_base.ts
@@ -25,19 +25,19 @@ export abstract class PlatformKit<PlatformConfig extends BasePlatformConfig = Ba
 
   get config() {
     const env = Z.object({
-      REPLEXICA_API_KEY: Z.string(),
-      REPLEXICA_PULL_REQUEST: Z.preprocess((val) => val === "true" || val === true, Z.boolean()),
-      REPLEXICA_COMMIT_MESSAGE: Z.string(),
-      REPLEXICA_PULL_REQUEST_TITLE: Z.string(),
-      REPLEXICA_WORKING_DIRECTORY: Z.string().optional().default("."),
+      LINGODOTDEV_API_KEY: Z.string(),
+      LINGODOTDEV_PULL_REQUEST: Z.preprocess((val) => val === "true" || val === true, Z.boolean()),
+      LINGODOTDEV_COMMIT_MESSAGE: Z.string(),
+      LINGODOTDEV_PULL_REQUEST_TITLE: Z.string(),
+      LINGODOTDEV_WORKING_DIRECTORY: Z.string().optional().default("."),
     }).parse(process.env);
 
     return {
-      replexicaApiKey: env.REPLEXICA_API_KEY,
-      isPullRequestMode: env.REPLEXICA_PULL_REQUEST,
-      commitMessage: env.REPLEXICA_COMMIT_MESSAGE,
-      pullRequestTitle: env.REPLEXICA_PULL_REQUEST_TITLE,
-      workingDir: env.REPLEXICA_WORKING_DIRECTORY,
+      replexicaApiKey: env.LINGODOTDEV_API_KEY,
+      isPullRequestMode: env.LINGODOTDEV_PULL_REQUEST,
+      commitMessage: env.LINGODOTDEV_COMMIT_MESSAGE,
+      pullRequestTitle: env.LINGODOTDEV_PULL_REQUEST_TITLE,
+      workingDir: env.LINGODOTDEV_WORKING_DIRECTORY,
     };
   }
 }

--- a/legacy/cli/bin/cli.mjs
+++ b/legacy/cli/bin/cli.mjs
@@ -2,16 +2,29 @@
 
 import CLI from "lingo.dev/cli";
 
-console.warn('\x1b[33m%s\x1b[0m', `
+const envVarConfigWarning = process.env.LINGODOTDEV_API_KEY
+  ? "\nThis version is not compatible with LINGODOTDEV_API_KEY env variable."
+  : "";
+
+console.warn(
+  "\x1b[33m%s\x1b[0m",
+  `
 ⚠️  WARNING: NEW PACKAGE AVAILABLE ⚠️
-=======================================
-This CLI version is deprecated.
+================================================================================
+This CLI version is deprecated.${envVarConfigWarning}
 Please use lingo.dev instead:
 
 npx lingo.dev@latest
 
 Visit https://lingo.dev for more information.
-=======================================
-`);
+================================================================================
+`,
+);
+
+process.env.LINGODOTDEV_API_KEY = process.env.REPLEXICA_API_KEY;
+process.env.LINGODOTDEV_PULL_REQUEST = process.env.REPLEXICA_PULL_REQUEST;
+process.env.LINGODOTDEV_PULL_REQUEST_TITLE = process.env.REPLEXICA_PULL_REQUEST_TITLE;
+process.env.LINGODOTDEV_COMMIT_MESSAGE = process.env.REPLEXICA_COMMIT_MESSAGE;
+process.env.LINGODOTDEV_WORKING_DIRECTORY = process.env.REPLEXICA_WORKING_DIRECTORY;
 
 await CLI.parseAsync(process.argv);

--- a/packages/cli/src/cli/cli/auth.ts
+++ b/packages/cli/src/cli/cli/auth.ts
@@ -56,7 +56,7 @@ Press Enter to open the browser for authentication.
 
 ---
 
-Having issues? Put REPLEXICA_API_KEY in your .env file instead.
+Having issues? Put LINGODOTDEV_API_KEY in your .env file instead.
     `.trim() + "\n",
     );
 

--- a/packages/cli/src/cli/utils/settings.ts
+++ b/packages/cli/src/cli/utils/settings.ts
@@ -12,11 +12,13 @@ export function getSettings(explicitApiKey: string | undefined): CliSettings {
   const systemFile = _loadSystemFile();
   const defaults = _loadDefaults();
 
+  _legacyEnvVarWarning();
+
   return {
     auth: {
-      apiKey: explicitApiKey || env.REPLEXICA_API_KEY || systemFile.auth?.apiKey || defaults.auth.apiKey,
-      apiUrl: env.REPLEXICA_API_URL || systemFile.auth?.apiUrl || defaults.auth.apiUrl,
-      webUrl: env.REPLEXICA_WEB_URL || systemFile.auth?.webUrl || defaults.auth.webUrl,
+      apiKey: explicitApiKey || env.LINGODOTDEV_API_KEY || systemFile.auth?.apiKey || defaults.auth.apiKey,
+      apiUrl: env.LINGODOTDEV_API_URL || systemFile.auth?.apiUrl || defaults.auth.apiUrl,
+      webUrl: env.LINGODOTDEV_WEB_URL || systemFile.auth?.webUrl || defaults.auth.webUrl,
     },
   };
 }
@@ -47,9 +49,9 @@ function _loadDefaults(): CliSettings {
 
 function _loadEnv() {
   return Z.object({
-    REPLEXICA_API_KEY: Z.string().optional(),
-    REPLEXICA_API_URL: Z.string().optional(),
-    REPLEXICA_WEB_URL: Z.string().optional(),
+    LINGODOTDEV_API_KEY: Z.string().optional(),
+    LINGODOTDEV_API_URL: Z.string().optional(),
+    LINGODOTDEV_WEB_URL: Z.string().optional(),
   })
     .passthrough()
     .parse(process.env);
@@ -82,4 +84,21 @@ function _getSettingsFilePath(): string {
   const homedir = os.homedir();
   const settingsFilePath = path.join(homedir, settingsFile);
   return settingsFilePath;
+}
+
+function _legacyEnvVarWarning() {
+  const env = _loadEnv();
+
+  if (env.REPLEXICA_API_KEY && !env.LINGODOTDEV_API_KEY) {
+    console.warn(
+      "\x1b[33m%s\x1b[0m",
+      `
+⚠️  WARNING: REPLEXICA_API_KEY env var is deprecated ⚠️
+===========================================================
+
+Please use LINGODOTDEV_API_KEY instead.
+===========================================================
+`,
+    );
+  }
 }


### PR DESCRIPTION
Warning in the old package, if it detects new config (new variable name present in env):

```
⚠️  WARNING: NEW PACKAGE AVAILABLE ⚠️
================================================================================
This CLI version is deprecated.
This version is not compatible with LINGODOTDEV_API_KEY env variable.
Please use lingo.dev instead:

npx lingo.dev@latest

Visit https://lingo.dev for more information.
================================================================================
```

Warning in the new package, if it detects old config (old variable name present in env, new variable name not present):
```
⚠️  WARNING: REPLEXICA_API_KEY env var is deprecated ⚠️
===========================================================

Please use LINGODOTDEV_API_KEY instead.
===========================================================
```