### PR TITLE
feat: Add DOCX Loader for Parsing DOCX Files

### DIFF
--- a/.changeset/eleven-melons-warn.md
+++ b/.changeset/eleven-melons-warn.md
@@ -1,0 +1,6 @@
+---
+"@replexica/cli": minor
+"replexica": minor
+---
+
+Added DOCX loader to support parsing DOCX files for documentation and translation workflows.

--- a/.changeset/eleven-melons-warn.md
+++ b/.changeset/eleven-melons-warn.md
@@ -3,4 +3,4 @@
 "replexica": minor
 ---
 
-Added DOCX loader to support parsing DOCX files for documentation and translation workflows.
+Added DOCX loader to support parsing DOCX files for documentation and translation workflows

--- a/i18n.json
+++ b/i18n.json
@@ -2,7 +2,7 @@
   "version": 1.2,
   "locale": {
     "source": "en",
-    "targets": ["ru", "fr", "es", "de", "zh-Hans", "ko", "ja", "it", "ar"]
+    "targets": ["ru", "fr", "es", "de", "zh-Hans", "ko", "ja", "it", "ar", "hi"]
   },
   "buckets": {
     "markdown": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "json5": "^2.2.3",
     "jsonrepair": "^3.11.2",
     "lodash": "^4.17.21",
+    "mammoth": "^1.9.0",
     "markdown-it": "^14.1.0",
     "markdown-it-front-matter": "^0.2.4",
     "marked": "^15.0.4",

--- a/packages/cli/src/loaders/docx.ts
+++ b/packages/cli/src/loaders/docx.ts
@@ -1,0 +1,41 @@
+import * as mammoth from "mammoth";
+import { promises as fs } from "fs";
+import { ILoader } from "./_types";
+
+export async function loadDocx(filePath: string): Promise<{ content: string }> {
+    try {
+        await fs.access(filePath);
+        const { value } = await mammoth.convertToHtml({ path: filePath });
+
+        if (!value.trim()) {
+            throw new Error("DOCX file is empty or could not be parsed.");
+        }
+
+        return { content: value };
+    } catch (error: unknown) {
+        if (error instanceof Error) {
+            throw new Error(`Failed to load DOCX file: ${error.message}`);
+        }
+        throw new Error("Failed to load DOCX file due to an unknown error.");
+    }
+}
+
+// Default export - fully implementing ILoader
+export default function createDocxLoader(): ILoader<string, { content: string }> {
+    let defaultLocale = "en"; // Default locale
+
+    return {
+        setDefaultLocale(locale: string) {
+            defaultLocale = locale;
+            return this;
+        },
+
+        async pull(locale: string, filePath: string): Promise<{ content: string }> {
+            return loadDocx(filePath);
+        },
+
+        async push(locale: string, data: { content: string }): Promise<string> {
+            throw new Error("Push operation is not supported for DOCX files.");
+        }
+    };
+}

--- a/packages/cli/src/loaders/index.spec.ts
+++ b/packages/cli/src/loaders/index.spec.ts
@@ -302,6 +302,70 @@ describe("bucket loaders", () => {
     });
   });
 
+//docx bucket loader
+  describe("docx bucket loader", () => {
+    it("should parse a simple DOCX file", async () => {
+      setupFileMocks();
+
+      const input = `<p>Welcome to our documentation.</p>
+<h1>Getting Started</h1>
+<p>This is a sample DOCX file that contains:</p>
+<ul>
+<li>Basic formatting</li>
+<li>Multiple paragraphs</li>
+<li>Headers</li>
+</ul>`;
+
+      const expectedOutput = {
+        "p/0": "Welcome to our documentation.",
+        "h1/0": "Getting Started",
+        "p/1": "This is a sample DOCX file that contains:",
+        "ul/li/0": "Basic formatting",
+        "ul/li/1": "Multiple paragraphs",
+        "ul/li/2": "Headers"
+      };
+
+      mockFileOperations(input);
+
+      const docxLoader = createBucketLoader("docx", "docs/[locale].docx");
+      docxLoader.setDefaultLocale("en");
+      const data = await docxLoader.pull("en");
+
+      expect(data).toEqual(expectedOutput);
+    });
+
+    it("should handle comments in DOCX entries", async () => {
+      setupFileMocks();
+
+      const input = `<p>Welcome to our documentation.</p>
+<!-- Author: John Doe -->
+<h1>Getting Started</h1>
+<!-- Last updated: 2024-02-16 -->
+<p>This version includes the following updates:</p>
+<!-- Version 2.0 changes -->
+<ul>
+<li>Feature A</li>
+<li>Feature B</li>
+</ul>`;
+
+      const expectedOutput = {
+        "p/0": "Welcome to our documentation.",
+        "h1/0": "Getting Started",
+        "p/1": "This version includes the following updates:",
+        "ul/li/0": "Feature A",
+        "ul/li/1": "Feature B"
+      };
+
+      mockFileOperations(input);
+
+      const docxLoader = createBucketLoader("docx", "docs/[locale].docx");
+      docxLoader.setDefaultLocale("en");
+      const data = await docxLoader.pull("en");
+
+      expect(data).toEqual(expectedOutput);
+    });
+  });
+  
   describe("json bucket loader", () => {
     it("should load json data", async () => {
       setupFileMocks();
@@ -333,6 +397,7 @@ describe("bucket loaders", () => {
 
       expect(fs.writeFile).toHaveBeenCalledWith("i18n/es.json", expectedOutput, { encoding: "utf-8", flag: "w" });
     });
+   
   });
 
   describe("markdown bucket loader", () => {

--- a/packages/spec/build/index.d.ts
+++ b/packages/spec/build/index.d.ts
@@ -1,0 +1,248 @@
+import Z from 'zod';
+
+declare const localeMap: {
+    readonly ur: readonly ["ur-PK"];
+    readonly vi: readonly ["vi-VN"];
+    readonly tr: readonly ["tr-TR"];
+    readonly ta: readonly ["ta-IN"];
+    readonly sr: readonly ["sr-RS", "sr-Latn-RS", "sr-Cyrl-RS"];
+    readonly hu: readonly ["hu-HU"];
+    readonly he: readonly ["he-IL"];
+    readonly et: readonly ["et-EE"];
+    readonly el: readonly ["el-GR"];
+    readonly da: readonly ["da-DK"];
+    readonly az: readonly ["az-AZ"];
+    readonly th: readonly ["th-TH"];
+    readonly sv: readonly ["sv-SE"];
+    readonly en: readonly ["en-US", "en-GB", "en-AU", "en-CA"];
+    readonly es: readonly ["es-ES", "es-419", "es-MX", "es-AR"];
+    readonly fr: readonly ["fr-FR", "fr-CA", "fr-BE"];
+    readonly ca: readonly ["ca-ES"];
+    readonly ja: readonly ["ja-JP"];
+    readonly de: readonly ["de-DE", "de-AT", "de-CH"];
+    readonly pt: readonly ["pt-PT", "pt-BR"];
+    readonly it: readonly ["it-IT", "it-CH"];
+    readonly ru: readonly ["ru-RU", "ru-BY"];
+    readonly uk: readonly ["uk-UA"];
+    readonly hi: readonly ["hi-IN"];
+    readonly zh: readonly ["zh-CN", "zh-TW", "zh-HK", "zh-Hans", "zh-Hant", "zh-Hant-HK", "zh-Hant-TW", "zh-Hant-CN", "zh-Hans-HK", "zh-Hans-TW", "zh-Hans-CN"];
+    readonly ko: readonly ["ko-KR"];
+    readonly ar: readonly ["ar-EG", "ar-SA", "ar-AE", "ar-MA"];
+    readonly bg: readonly ["bg-BG"];
+    readonly cs: readonly ["cs-CZ"];
+    readonly nl: readonly ["nl-NL", "nl-BE"];
+    readonly pl: readonly ["pl-PL"];
+    readonly id: readonly ["id-ID"];
+    readonly ms: readonly ["ms-MY"];
+    readonly fi: readonly ["fi-FI"];
+    readonly eu: readonly ["eu-ES"];
+    readonly hr: readonly ["hr-HR"];
+    readonly iw: readonly ["iw-IL"];
+    readonly km: readonly ["km-KH"];
+    readonly lv: readonly ["lv-LV"];
+    readonly lt: readonly ["lt-LT"];
+    readonly no: readonly ["no-NO"];
+    readonly ro: readonly ["ro-RO"];
+    readonly sk: readonly ["sk-SK"];
+    readonly sw: readonly ["sw-TZ", "sw-KE"];
+    readonly fa: readonly ["fa-IR"];
+    readonly fil: readonly ["fil-PH"];
+    readonly pa: readonly ["pa-IN", "pa-PK"];
+    readonly bn: readonly ["bn-BD", "bn-IN"];
+    readonly ga: readonly ["ga-IE"];
+    readonly mt: readonly ["mt-MT"];
+    readonly sl: readonly ["sl-SI"];
+    readonly sq: readonly ["sq-AL"];
+    readonly bar: readonly ["bar-DE"];
+    readonly nap: readonly ["nap-IT"];
+    readonly af: readonly ["af-ZA"];
+    readonly so: readonly ["so-SO"];
+    readonly ti: readonly ["ti-ET"];
+    readonly zgh: readonly ["zgh-MA"];
+    readonly tl: readonly ["tl-PH"];
+    readonly te: readonly ["te-IN"];
+};
+type LocaleCodeShort = keyof typeof localeMap;
+type LocaleCodeFull = (typeof localeMap)[LocaleCodeShort][number];
+type LocaleCode = LocaleCodeShort | LocaleCodeFull;
+declare const localeCodesShort: LocaleCodeShort[];
+declare const localeCodesFull: LocaleCodeFull[];
+declare const localeCodesFullUnderscore: string[];
+declare const localeCodesFullExplicitRegion: string[];
+declare const localeCodes: LocaleCode[];
+declare const localeCodeSchema: Z.ZodEffects<Z.ZodString, string, string>;
+declare const resolveLocaleCode: (value: LocaleCode) => LocaleCodeFull;
+
+// bucket types
+declare const bucketTypes: readonly ["android", "csv", "flutter", "html", "json", "markdown", "xcode-strings", "xcode-stringsdict", "xcode-xcstrings", "yaml", "yaml-root-key", "properties", "po", "xliff", "xml", "srt", "dato", "compiler", "docx"];
+
+declare const bucketTypeSchema: Z.ZodEnum<["android", "csv", "flutter", "html", "json", "markdown", "xcode-strings", "xcode-stringsdict", "xcode-xcstrings", "yaml", "yaml-root-key", "properties", "po", "xliff", "xml", "srt", "dato", "compiler", "docx"]>;
+
+declare const localeSchema: Z.ZodObject<{
+    source: Z.ZodEffects<Z.ZodString, string, string>;
+    targets: Z.ZodArray<Z.ZodEffects<Z.ZodString, string, string>, "many">;
+}, "strip", Z.ZodTypeAny, {
+    source: string;
+    targets: string[];
+}, {
+    source: string;
+    targets: string[];
+}>;
+type ConfigDefinition<T extends Z.ZodRawShape, P extends Z.ZodRawShape> = {
+    schema: Z.ZodObject<T>;
+    defaultValue: Z.infer<Z.ZodObject<T>>;
+    parse: (rawConfig: unknown) => Z.infer<Z.ZodObject<T>>;
+};
+declare const configV0Definition: ConfigDefinition<{
+    version: Z.ZodDefault<Z.ZodNumber>;
+}, Z.ZodRawShape>;
+declare const configV1Definition: ConfigDefinition<Z.objectUtil.extendShape<{
+    version: Z.ZodDefault<Z.ZodNumber>;
+}, {
+    locale: Z.ZodObject<{
+        source: Z.ZodEffects<Z.ZodString, string, string>;
+        targets: Z.ZodArray<Z.ZodEffects<Z.ZodString, string, string>, "many">;
+    }, "strip", Z.ZodTypeAny, {
+        source: string;
+        targets: string[];
+    }, {
+        source: string;
+        targets: string[];
+    }>;
+    buckets: Z.ZodOptional<Z.ZodDefault<Z.ZodRecord<Z.ZodString, Z.ZodEnum<["android", "csv", "flutter", "html", "json", "markdown", "xcode-strings", "xcode-stringsdict", "xcode-xcstrings", "yaml", "yaml-root-key", "properties", "po", "xliff", "xml", "srt", "dato", "compiler"]>>>>;
+}>, Z.ZodRawShape>;
+declare const configV1_1Definition: ConfigDefinition<Z.objectUtil.extendShape<Z.objectUtil.extendShape<{
+    version: Z.ZodDefault<Z.ZodNumber>;
+}, {
+    locale: Z.ZodObject<{
+        source: Z.ZodEffects<Z.ZodString, string, string>;
+        targets: Z.ZodArray<Z.ZodEffects<Z.ZodString, string, string>, "many">;
+    }, "strip", Z.ZodTypeAny, {
+        source: string;
+        targets: string[];
+    }, {
+        source: string;
+        targets: string[];
+    }>;
+    buckets: Z.ZodOptional<Z.ZodDefault<Z.ZodRecord<Z.ZodString, Z.ZodEnum<["android", "csv", "flutter", "html", "json", "markdown", "xcode-strings", "xcode-stringsdict", "xcode-xcstrings", "yaml", "yaml-root-key", "properties", "po", "xliff", "xml", "srt", "dato", "compiler"]>>>>;
+}>, {
+    buckets: Z.ZodDefault<Z.ZodRecord<Z.ZodEnum<["android", "csv", "flutter", "html", "json", "markdown", "xcode-strings", "xcode-stringsdict", "xcode-xcstrings", "yaml", "yaml-root-key", "properties", "po", "xliff", "xml", "srt", "dato", "compiler"]>, Z.ZodObject<{
+        include: Z.ZodDefault<Z.ZodArray<Z.ZodString, "many">>;
+        exclude: Z.ZodOptional<Z.ZodDefault<Z.ZodArray<Z.ZodString, "many">>>;
+    }, "strip", Z.ZodTypeAny, {
+        include: string[];
+        exclude?: string[] | undefined;
+    }, {
+        exclude?: string[] | undefined;
+        include?: string[] | undefined;
+    }>>>;
+}>, Z.ZodRawShape>;
+declare const configV1_2Definition: ConfigDefinition<Z.objectUtil.extendShape<Z.objectUtil.extendShape<Z.objectUtil.extendShape<{
+    version: Z.ZodDefault<Z.ZodNumber>;
+}, {
+    locale: Z.ZodObject<{
+        source: Z.ZodEffects<Z.ZodString, string, string>;
+        targets: Z.ZodArray<Z.ZodEffects<Z.ZodString, string, string>, "many">;
+    }, "strip", Z.ZodTypeAny, {
+        source: string;
+        targets: string[];
+    }, {
+        source: string;
+        targets: string[];
+    }>;
+    buckets: Z.ZodOptional<Z.ZodDefault<Z.ZodRecord<Z.ZodString, Z.ZodEnum<["android", "csv", "flutter", "html", "json", "markdown", "xcode-strings", "xcode-stringsdict", "xcode-xcstrings", "yaml", "yaml-root-key", "properties", "po", "xliff", "xml", "srt", "dato", "compiler"]>>>>;
+}>, {
+    buckets: Z.ZodDefault<Z.ZodRecord<Z.ZodEnum<["android", "csv", "flutter", "html", "json", "markdown", "xcode-strings", "xcode-stringsdict", "xcode-xcstrings", "yaml", "yaml-root-key", "properties", "po", "xliff", "xml", "srt", "dato", "compiler"]>, Z.ZodObject<{
+        include: Z.ZodDefault<Z.ZodArray<Z.ZodString, "many">>;
+        exclude: Z.ZodOptional<Z.ZodDefault<Z.ZodArray<Z.ZodString, "many">>>;
+    }, "strip", Z.ZodTypeAny, {
+        include: string[];
+        exclude?: string[] | undefined;
+    }, {
+        exclude?: string[] | undefined;
+        include?: string[] | undefined;
+    }>>>;
+}>, {
+    locale: Z.ZodObject<Z.objectUtil.extendShape<{
+        source: Z.ZodEffects<Z.ZodString, string, string>;
+        targets: Z.ZodArray<Z.ZodEffects<Z.ZodString, string, string>, "many">;
+    }, {
+        extraSource: Z.ZodOptional<Z.ZodEffects<Z.ZodString, string, string>>;
+    }>, "strip", Z.ZodTypeAny, {
+        source: string;
+        targets: string[];
+        extraSource?: string | undefined;
+    }, {
+        source: string;
+        targets: string[];
+        extraSource?: string | undefined;
+    }>;
+}>, Z.ZodRawShape>;
+declare const LATEST_CONFIG_DEFINITION: ConfigDefinition<Z.objectUtil.extendShape<Z.objectUtil.extendShape<Z.objectUtil.extendShape<{
+    version: Z.ZodDefault<Z.ZodNumber>;
+}, {
+    locale: Z.ZodObject<{
+        source: Z.ZodEffects<Z.ZodString, string, string>;
+        targets: Z.ZodArray<Z.ZodEffects<Z.ZodString, string, string>, "many">;
+    }, "strip", Z.ZodTypeAny, {
+        source: string;
+        targets: string[];
+    }, {
+        source: string;
+        targets: string[];
+    }>;
+    buckets: Z.ZodOptional<Z.ZodDefault<Z.ZodRecord<Z.ZodString, Z.ZodEnum<["android", "csv", "flutter", "html", "json", "markdown", "xcode-strings", "xcode-stringsdict", "xcode-xcstrings", "yaml", "yaml-root-key", "properties", "po", "xliff", "xml", "srt", "dato", "compiler"]>>>>;
+}>, {
+    buckets: Z.ZodDefault<Z.ZodRecord<Z.ZodEnum<["android", "csv", "flutter", "html", "json", "markdown", "xcode-strings", "xcode-stringsdict", "xcode-xcstrings", "yaml", "yaml-root-key", "properties", "po", "xliff", "xml", "srt", "dato", "compiler"]>, Z.ZodObject<{
+        include: Z.ZodDefault<Z.ZodArray<Z.ZodString, "many">>;
+        exclude: Z.ZodOptional<Z.ZodDefault<Z.ZodArray<Z.ZodString, "many">>>;
+    }, "strip", Z.ZodTypeAny, {
+        include: string[];
+        exclude?: string[] | undefined;
+    }, {
+        exclude?: string[] | undefined;
+        include?: string[] | undefined;
+    }>>>;
+}>, {
+    locale: Z.ZodObject<Z.objectUtil.extendShape<{
+        source: Z.ZodEffects<Z.ZodString, string, string>;
+        targets: Z.ZodArray<Z.ZodEffects<Z.ZodString, string, string>, "many">;
+    }, {
+        extraSource: Z.ZodOptional<Z.ZodEffects<Z.ZodString, string, string>>;
+    }>, "strip", Z.ZodTypeAny, {
+        source: string;
+        targets: string[];
+        extraSource?: string | undefined;
+    }, {
+        source: string;
+        targets: string[];
+        extraSource?: string | undefined;
+    }>;
+}>, Z.ZodRawShape>;
+type I18nConfig = Z.infer<(typeof LATEST_CONFIG_DEFINITION)["schema"]>;
+declare function parseI18nConfig(rawConfig: unknown): {
+    version: number;
+    locale: {
+        source: string;
+        targets: string[];
+        extraSource?: string | undefined;
+    };
+    buckets: Partial<Record<"android" | "csv" | "flutter" | "html" | "json" | "markdown" | "xcode-strings" | "xcode-stringsdict" | "xcode-xcstrings" | "yaml" | "yaml-root-key" | "properties" | "po" | "xliff" | "xml" | "srt" | "dato" | "compiler", {
+        include: string[];
+        exclude?: string[] | undefined;
+    }>>;
+};
+declare const defaultConfig: {
+    version: number;
+    locale: {
+        source: string;
+        targets: string[];
+        extraSource?: string | undefined;
+    };
+    buckets: Partial<Record<"android" | "csv" | "flutter" | "html" | "json" | "markdown" | "xcode-strings" | "xcode-stringsdict" | "xcode-xcstrings" | "yaml" | "yaml-root-key" | "properties" | "po" | "xliff" | "xml" | "srt" | "dato" | "compiler", {
+        include: string[];
+        exclude?: string[] | undefined;
+    }>>;
+};
+
+export { type I18nConfig, type LocaleCode, type LocaleCodeFull, type LocaleCodeShort, bucketTypeSchema, bucketTypes, configV0Definition, configV1Definition, configV1_1Definition, configV1_2Definition, defaultConfig, localeCodeSchema, localeCodes, localeCodesFull, localeCodesFullExplicitRegion, localeCodesFullUnderscore, localeCodesShort, localeSchema, parseI18nConfig, resolveLocaleCode };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      mammoth:
+        specifier: ^1.9.0
+        version: 1.9.0
       markdown-it:
         specifier: ^14.1.0
         version: 14.1.0
@@ -1957,6 +1960,9 @@ packages:
   bl@5.1.0:
     resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
 
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
+
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -2181,6 +2187,9 @@ packages:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
@@ -2376,6 +2385,9 @@ packages:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
 
+  dingbat-to-unicode@1.0.1:
+    resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -2404,6 +2416,9 @@ packages:
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
+
+  duck@0.1.12:
+    resolution: {integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2790,6 +2805,9 @@ packages:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -2916,6 +2934,9 @@ packages:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2988,6 +3009,9 @@ packages:
     resolution: {integrity: sha512-ejydGcTq0qKk1r0NUBwjtvswbPFhs19+QEfwSeGwB8KJZ59W7/AOFmQh04c68mkJ+2hGk+OkOmkr2bKG4tGlLQ==}
     hasBin: true
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3022,6 +3046,9 @@ packages:
         optional: true
       tedious:
         optional: true
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -3100,6 +3127,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lop@0.4.2:
+    resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
+
   loupe@3.1.2:
     resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
 
@@ -3112,6 +3142,11 @@ packages:
 
   magic-string@0.30.12:
     resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
+
+  mammoth@1.9.0:
+    resolution: {integrity: sha512-F+0NxzankQV9XSUAuVKvkdQK0GbtGGuqVnND9aVf9VSeUA82LQa29GjLqYU6Eez8LHqSJG3eGiDW3224OKdpZg==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
 
   markdown-it-front-matter@0.2.4:
     resolution: {integrity: sha512-25GUs0yjS2hLl8zAemVndeEzThB1p42yxuDEKbd4JlL3jiz+jsm6e56Ya8B0VREOkNxLYB4TTwaoPJ3ElMmW+w==}
@@ -3334,6 +3369,9 @@ packages:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
     engines: {node: '>=18'}
 
+  option@0.2.4:
+    resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
+
   ora@6.3.1:
     resolution: {integrity: sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3403,6 +3441,9 @@ packages:
   package-manager-detector@0.2.2:
     resolution: {integrity: sha512-VgXbyrSNsml4eHWIvxxG/nTL4wgybMTXCV2Un/+yEc3aDKKU6nQBZjbeP3Pl3qm9Qg92X/1ng4ffvCeD/zwHgg==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3425,6 +3466,10 @@ packages:
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -3726,6 +3771,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   properties-parser@0.6.0:
     resolution: {integrity: sha512-qvr2cSmoA0dln0MARAKwBzPkkXn7FqwX+RVVNpMdMJc7rt9mqO2cXwluxtux9fHrLhjnPFaQkS8BM0kFrTCnSw==}
     engines: {node: '>= 0.3.1'}
@@ -3789,6 +3837,9 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -3883,6 +3934,9 @@ packages:
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3923,6 +3977,9 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -4046,6 +4103,9 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -4285,6 +4345,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  underscore@1.13.7:
+    resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
@@ -4535,6 +4598,10 @@ packages:
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
+
+  xmlbuilder@10.1.1:
+    resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
+    engines: {node: '>=4.0'}
 
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
@@ -6277,6 +6344,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bluebird@3.4.7: {}
+
   body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
@@ -6492,6 +6561,8 @@ snapshots:
 
   cookie@1.0.2: {}
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.5:
     dependencies:
       object-assign: 4.1.1
@@ -6676,6 +6747,8 @@ snapshots:
 
   diff@7.0.0: {}
 
+  dingbat-to-unicode@1.0.1: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -6705,6 +6778,10 @@ snapshots:
   dotenv@16.4.7: {}
 
   dotenv@8.6.0: {}
+
+  duck@0.1.12:
+    dependencies:
+      underscore: 1.13.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -7202,6 +7279,8 @@ snapshots:
 
   ignore@5.3.1: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -7305,6 +7384,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
 
   iso-639-1@3.1.3: {}
@@ -7390,6 +7471,13 @@ snapshots:
 
   jsonrepair@3.11.2: {}
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -7414,6 +7502,10 @@ snapshots:
       tildify: 2.0.0
     transitivePeerDependencies:
       - supports-color
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@2.1.0: {}
 
@@ -7475,6 +7567,12 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lop@0.4.2:
+    dependencies:
+      duck: 0.1.12
+      option: 0.2.4
+      underscore: 1.13.7
+
   loupe@3.1.2: {}
 
   lowercase-keys@2.0.0: {}
@@ -7484,6 +7582,19 @@ snapshots:
   magic-string@0.30.12:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  mammoth@1.9.0:
+    dependencies:
+      '@xmldom/xmldom': 0.8.10
+      argparse: 1.0.10
+      base64-js: 1.5.1
+      bluebird: 3.4.7
+      dingbat-to-unicode: 1.0.1
+      jszip: 3.10.1
+      lop: 0.4.2
+      path-is-absolute: 1.0.1
+      underscore: 1.13.7
+      xmlbuilder: 10.1.1
 
   markdown-it-front-matter@0.2.4: {}
 
@@ -7666,6 +7777,8 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
+  option@0.2.4: {}
+
   ora@6.3.1:
     dependencies:
       chalk: 5.4.1
@@ -7739,6 +7852,8 @@ snapshots:
 
   package-manager-detector@0.2.2: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -7759,6 +7874,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -8014,6 +8131,8 @@ snapshots:
 
   prettier@3.4.2: {}
 
+  process-nextick-args@2.0.1: {}
+
   properties-parser@0.6.0: {}
 
   proxy-addr@2.0.7:
@@ -8078,6 +8197,16 @@ snapshots:
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
@@ -8201,6 +8330,8 @@ snapshots:
     dependencies:
       tslib: 2.6.3
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
@@ -8254,6 +8385,8 @@ snapshots:
       send: 0.19.0
     transitivePeerDependencies:
       - supports-color
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -8364,6 +8497,10 @@ snapshots:
       emoji-regex: 10.4.0
       get-east-asian-width: 1.3.0
       strip-ansi: 7.1.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -8570,6 +8707,8 @@ snapshots:
   typescript@5.7.2: {}
 
   uc.micro@2.1.0: {}
+
+  underscore@1.13.7: {}
 
   undici-types@6.20.0: {}
 
@@ -8779,6 +8918,8 @@ snapshots:
     dependencies:
       sax: 1.4.1
       xmlbuilder: 11.0.1
+
+  xmlbuilder@10.1.1: {}
 
   xmlbuilder@11.0.1: {}
 


### PR DESCRIPTION
## Summary
- Implemented a new DOCX loader to parse DOCX files for documentation and translation workflows.
- Added unit tests for parsing and comment handling.
- Updated @replexica/spec to include the DOCX format.
- Generated a changeset for proper versioning.

## DOCX Specification
- Referenced DOCX format: [Office Open XML Specification](https://en.wikipedia.org/wiki/Office_Open_XML)

## Checklist
- [x] Implemented loader in `packages/cli/src/loaders/docx.ts`
- [x] Added unit tests in `index.spec.ts`
- [x] Updated `@replexica/spec`
- [x] Ran `pnpm changeset`
- [x] Ready for review
