### PR TITLE
feat(cli): warn if env vars override values from "auth --login"

### DIFF
--- a/.changeset/dry-items-applaud.md
+++ b/.changeset/dry-items-applaud.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+warn if env vars override values from "auth --login"

--- a/packages/cli/src/cli/utils/settings.ts
+++ b/packages/cli/src/cli/utils/settings.ts
@@ -14,6 +14,8 @@ export function getSettings(explicitApiKey: string | undefined): CliSettings {
 
   _legacyEnvVarWarning();
 
+  _envVarsWarning();
+
   return {
     auth: {
       apiKey: explicitApiKey || env.LINGODOTDEV_API_KEY || systemFile.auth?.apiKey || defaults.auth.apiKey,
@@ -100,5 +102,23 @@ Please use LINGODOTDEV_API_KEY instead.
 ===========================================================
 `,
     );
+  }
+}
+
+function _envVarsWarning() {
+  const env = _loadEnv();
+  const systemFile = _loadSystemFile();
+
+  if (env.LINGODOTDEV_API_KEY && systemFile.auth?.apiKey) {
+    console.warn(
+      "\x1b[33m%s\x1b[0m",
+      `⚠️  WARNING: Using LINGODOTDEV_API_KEY env var instead of credentials from login flow (saved in .lingodotdevrc)`,
+    );
+  }
+  if (env.LINGODOTDEV_API_URL) {
+    console.warn("\x1b[33m%s\x1b[0m", `⚠️  WARNING: Using LINGODOTDEV_API_URL: ${env.LINGODOTDEV_API_URL}`);
+  }
+  if (env.LINGODOTDEV_WEB_URL) {
+    console.warn("\x1b[33m%s\x1b[0m", `⚠️  WARNING: Using LINGODOTDEV_WEB_URL: ${env.LINGODOTDEV_WEB_URL}`);
   }
 }


### PR DESCRIPTION
Only warn when there is API key in  `.lingodotdevrc` to avoid warnings in CI env.