### PR TITLE
feat(cli): support prettier plugins

### DIFF
--- a/.changeset/flat-emus-hunt.md
+++ b/.changeset/flat-emus-hunt.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+support prettier plugins

--- a/packages/cli/src/cli/loaders/prettier.ts
+++ b/packages/cli/src/cli/loaders/prettier.ts
@@ -1,7 +1,9 @@
+import fs from "fs";
 import path from "path";
 import prettier, { Options } from "prettier";
 import { ILoader } from "./_types";
 import { createLoader } from "./_utils";
+import { execSync } from "child_process";
 
 export type PrettierLoaderOptions = {
   parser: Options["parser"];
@@ -23,7 +25,7 @@ export default function createPrettierLoader(options: PrettierLoaderOptions): IL
         return data;
       }
 
-      const result = prettier.format(data, {
+      const config: Options = {
         ...(prettierConfig || { printWidth: 2500, bracketSameLine: false }),
         parser: options.parser,
         // For HTML parser, preserve comments and quotes
@@ -34,9 +36,29 @@ export default function createPrettierLoader(options: PrettierLoaderOptions): IL
               embeddedLanguageFormatting: "off",
             }
           : {}),
-      });
+      };
 
-      return result;
+      try {
+        const result = await prettier.format(data, config);
+        return result;
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith("Cannot find package")) {
+          console.log();
+          console.log("Prettier is missing some dependecies - installing all project dependencies");
+
+          // prettier is missing dependencies - install all project dependencies
+          installDependencies();
+
+          // clear file system structure cache to find newly installed dependencies
+          await prettier.clearConfigCache();
+
+          // try to format again
+          const result = await prettier.format(data, config);
+          return result;
+        } else {
+          throw error;
+        }
+      }
     },
   });
 }
@@ -48,4 +70,25 @@ async function loadPrettierConfig(filePath: string) {
   } catch (error) {
     return {};
   }
+}
+
+// install all dependencies using package manager
+async function installDependencies() {
+  const packageManager = await getPackageManager();
+  console.log(`Installing dependencies using ${packageManager}`);
+  execSync(`${packageManager} install --frozen-lockfile`, { stdio: "inherit" });
+  console.log(`Dependencies installed`);
+}
+
+// determine if yarn or pnpm is used based on lockfile, otherwise use npm
+async function getPackageManager() {
+  const yarnLockfile = path.resolve(process.cwd(), "yarn.lock");
+  const pnpmLockfile = path.resolve(process.cwd(), "pnpm-lock.yaml");
+  if (fs.existsSync(yarnLockfile)) {
+    return "yarn";
+  }
+  if (fs.existsSync(pnpmLockfile)) {
+    return "pnpm";
+  }
+  return "npm";
 }


### PR DESCRIPTION
## New functionality

1. try to run prettier (if there are no plugins it will run correctly on first try)
2. if it fails to run install all project dependencies (in order to use package manager lock file)
3. try to run again (if the issue was with missing dependencies, it will run correctly this time)

It does not affect prettier configurations without plugins.

## Preview

![Screenshot 2025-03-20 at 23 33 29](https://github.com/user-attachments/assets/17d56493-86ff-44c5-8a54-9b56d5e6a02e)
