### PR TITLE
feat(sdk): handle errors from i18n when streaming

### DIFF
--- a/.changeset/tender-suns-cry.md
+++ b/.changeset/tender-suns-cry.md
@@ -1,0 +1,6 @@
+---
+"lingo.dev": patch
+"@lingo.dev/_sdk": patch
+---
+
+handle errors from i18n when streaming

--- a/packages/cli/src/cli/cmd/i18n.ts
+++ b/packages/cli/src/cli/cmd/i18n.ts
@@ -401,7 +401,7 @@ async function retryWithExponentialBackoff<T>(
 }
 
 function createLocalizationEngineConnection(params: { apiKey: string; apiUrl: string; maxRetries?: number }) {
-  const replexicaEngine = new LingoDotDevEngine({
+  const engine = new LingoDotDevEngine({
     apiKey: params.apiKey,
     apiUrl: params.apiUrl,
   });
@@ -423,7 +423,7 @@ function createLocalizationEngineConnection(params: { apiKey: string; apiUrl: st
     ) => {
       return retryWithExponentialBackoff(
         () =>
-          replexicaEngine.localizeObject(
+          engine.localizeObject(
             args.processableData,
             {
               sourceLocale: args.sourceLocale,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -129,6 +129,12 @@ export class LingoDotDevEngine {
     }
 
     const jsonResponse = await res.json();
+
+    // when streaming the error is returned in the response body
+    if (!jsonResponse.data && jsonResponse.error) {
+      throw new Error(jsonResponse.error);
+    }
+
     return jsonResponse.data || {};
   }
 


### PR DESCRIPTION
# CLI

Log error, eg. when translated words limit is reached on free plan:

![Screenshot 2025-03-25 at 14 25 31](https://github.com/user-attachments/assets/2b2cc1b2-7285-4535-97d3-31d22915f466)

# SDK

Throw an error, eg. when translated words limit is reached on free plan:

![Screenshot 2025-03-25 at 14 25 08](https://github.com/user-attachments/assets/1ce70cc5-0d90-45a4-95eb-26278fe98116)
