### PR TITLE
fix: fixed typo for backward compatibility

### DIFF
--- a/packages/cli/src/cli/cmd/cleanup.ts
+++ b/packages/cli/src/cli/cmd/cleanup.ts
@@ -1,4 +1,4 @@
-import { I18nConfig, resolveOverridenLocale } from "@lingo.dev/_spec";
+import { I18nConfig, resolveOverriddenLocale } from "@lingo.dev/_spec";
 import { Command } from "interactive-commander";
 import _ from "lodash";
 import { getConfig } from "../utils/config";
@@ -38,7 +38,7 @@ export default new Command()
         ora.info(`Processing bucket: ${bucket.type}`);
 
         for (const bucketConfig of bucket.config) {
-          const sourceLocale = resolveOverridenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
+          const sourceLocale = resolveOverriddenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
           const bucketOra = Ora({ indent: 2 }).info(`Processing path: ${bucketConfig.pathPattern}`);
           const bucketLoader = createBucketLoader(bucket.type, bucketConfig.pathPattern, { isCacheRestore: false, defaultLocale: sourceLocale });
           bucketLoader.setDefaultLocale(sourceLocale);
@@ -48,7 +48,7 @@ export default new Command()
           const sourceKeys = Object.keys(sourceData);
 
           for (const _targetLocale of targetLocales) {
-            const targetLocale = resolveOverridenLocale(_targetLocale, bucketConfig.delimiter);
+            const targetLocale = resolveOverriddenLocale(_targetLocale, bucketConfig.delimiter);
             try {
               const targetData = await bucketLoader.pull(targetLocale);
               const targetKeys = Object.keys(targetData);

--- a/packages/cli/src/cli/cmd/i18n.ts
+++ b/packages/cli/src/cli/cmd/i18n.ts
@@ -1,4 +1,4 @@
-import { bucketTypeSchema, I18nConfig, localeCodeSchema, resolveOverridenLocale } from "@lingo.dev/_spec";
+import { bucketTypeSchema, I18nConfig, localeCodeSchema, resolveOverriddenLocale } from "@lingo.dev/_spec";
 import { LingoDotDevEngine } from "@lingo.dev/_sdk";
 import { Command } from "interactive-commander";
 import Z from "zod";
@@ -79,7 +79,7 @@ export default new Command()
         ora.start("Creating i18n.lock...");
         for (const bucket of buckets) {
           for (const bucketConfig of bucket.config) {
-            const sourceLocale = resolveOverridenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
+            const sourceLocale = resolveOverriddenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
 
             const bucketLoader = createBucketLoader(bucket.type, bucketConfig.pathPattern, {
               isCacheRestore: false,
@@ -110,7 +110,7 @@ export default new Command()
             const bucketOra = Ora({ indent: 4 });
             bucketOra.info(`Processing path: ${bucketConfig.pathPattern}`);
 
-            const sourceLocale = resolveOverridenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
+            const sourceLocale = resolveOverriddenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
             const bucketLoader = createBucketLoader(bucket.type, bucketConfig.pathPattern, {
               isCacheRestore: true,
               defaultLocale: sourceLocale,
@@ -154,7 +154,7 @@ export default new Command()
         let requiresUpdate: string | null = null;
         bucketLoop: for (const bucket of buckets) {
           for (const bucketConfig of bucket.config) {
-            const sourceLocale = resolveOverridenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
+            const sourceLocale = resolveOverriddenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
 
             const bucketLoader = createBucketLoader(bucket.type, bucketConfig.pathPattern, {
               isCacheRestore: false,
@@ -176,7 +176,7 @@ export default new Command()
             }
 
             for (const _targetLocale of targetLocales) {
-              const targetLocale = resolveOverridenLocale(_targetLocale, bucketConfig.delimiter);
+              const targetLocale = resolveOverriddenLocale(_targetLocale, bucketConfig.delimiter);
               const { unlocalizable: targetUnlocalizable, ...targetData } = await bucketLoader.pull(targetLocale);
 
               const missingKeys = _.difference(Object.keys(sourceData), Object.keys(targetData));
@@ -227,7 +227,7 @@ export default new Command()
           for (const bucketConfig of bucket.config) {
             const bucketOra = Ora({ indent: 2 }).info(`Processing path: ${bucketConfig.pathPattern}`);
 
-            const sourceLocale = resolveOverridenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
+            const sourceLocale = resolveOverriddenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
 
             const bucketLoader = createBucketLoader(bucket.type, bucketConfig.pathPattern, {
               isCacheRestore: false,
@@ -238,7 +238,7 @@ export default new Command()
             let sourceData = await bucketLoader.pull(sourceLocale);
 
             for (const _targetLocale of targetLocales) {
-              const targetLocale = resolveOverridenLocale(_targetLocale, bucketConfig.delimiter);
+              const targetLocale = resolveOverriddenLocale(_targetLocale, bucketConfig.delimiter);
               try {
                 bucketOra.start(`[${sourceLocale} -> ${targetLocale}] (0%) Localization in progress...`);
 

--- a/packages/cli/src/cli/cmd/lockfile.ts
+++ b/packages/cli/src/cli/cmd/lockfile.ts
@@ -2,10 +2,11 @@ import { Command } from "interactive-commander";
 import Z from "zod";
 import Ora from "ora";
 import { createLockfileHelper } from "../utils/lockfile";
-import { bucketTypeSchema, resolveOverridenLocale } from "@lingo.dev/_spec";
+import { bucketTypeSchema, resolveOverriddenLocale } from "@lingo.dev/_spec";
 import { getConfig } from "../utils/config";
 import createBucketLoader from "../loaders";
 import { getBuckets } from "../utils/buckets";
+
 
 export default new Command()
   .command("lockfile")
@@ -25,7 +26,7 @@ export default new Command()
 
       for (const bucket of buckets) {
         for (const bucketConfig of bucket.config) {
-          const sourceLocale = resolveOverridenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
+          const sourceLocale = resolveOverriddenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
           const bucketLoader = createBucketLoader(bucket.type, bucketConfig.pathPattern, { isCacheRestore: false, defaultLocale: sourceLocale });
           bucketLoader.setDefaultLocale(sourceLocale);
 

--- a/packages/cli/src/cli/cmd/show/files.ts
+++ b/packages/cli/src/cli/cmd/show/files.ts
@@ -4,7 +4,7 @@ import Ora from "ora";
 import { getConfig } from "../../utils/config";
 import { CLIError } from "../../utils/errors";
 import { getBuckets } from "../../utils/buckets";
-import { resolveOverridenLocale } from "@lingo.dev/_spec";
+import { resolveOverriddenLocale } from "@lingo.dev/_spec";
 
 export default new Command()
   .command("files")
@@ -28,10 +28,10 @@ export default new Command()
         const buckets = getBuckets(i18nConfig);
         for (const bucket of buckets) {
           for (const bucketConfig of bucket.config) {
-            const sourceLocale = resolveOverridenLocale(i18nConfig.locale.source, bucketConfig.delimiter);
+            const sourceLocale = resolveOverriddenLocale(i18nConfig.locale.source, bucketConfig.delimiter);
             const sourcePath = bucketConfig.pathPattern.replace(/\[locale\]/g, sourceLocale);
             const targetPaths = i18nConfig.locale.targets.map((_targetLocale) => {
-              const targetLocale = resolveOverridenLocale(_targetLocale, bucketConfig.delimiter);
+              const targetLocale = resolveOverriddenLocale(_targetLocale, bucketConfig.delimiter);
               return bucketConfig.pathPattern.replace(/\[locale\]/g, targetLocale);
             });
 

--- a/packages/cli/src/cli/utils/buckets.ts
+++ b/packages/cli/src/cli/utils/buckets.ts
@@ -2,9 +2,10 @@ import _ from "lodash";
 import path from "path";
 import { glob } from "glob";
 import { CLIError } from "./errors";
-import { I18nConfig, resolveOverridenLocale, BucketItem } from "@lingo.dev/_spec";
+import { I18nConfig, resolveOverriddenLocale, BucketItem } from "@lingo.dev/_spec";
 import { bucketTypeSchema } from "@lingo.dev/_spec";
 import Z from "zod";
+
 
 export function getBuckets(i18nConfig: I18nConfig) {
   const result = Object.entries(i18nConfig.buckets).map(([bucketType, bucketEntry]) => {
@@ -21,7 +22,7 @@ export function getBuckets(i18nConfig: I18nConfig) {
 
 function extractPathPatterns(sourceLocale: string, include: BucketItem[], exclude?: BucketItem[]) {
   const includedPatterns = include.flatMap((pattern) =>
-    expandPlaceholderedGlob(pattern.path, resolveOverridenLocale(sourceLocale, pattern.delimiter)).map(
+    expandPlaceholderedGlob(pattern.path, resolveOverriddenLocale(sourceLocale, pattern.delimiter)).map(
       (pathPattern) => ({
         pathPattern,
         delimiter: pattern.delimiter,
@@ -29,7 +30,7 @@ function extractPathPatterns(sourceLocale: string, include: BucketItem[], exclud
     ),
   );
   const excludedPatterns = exclude?.flatMap((pattern) =>
-    expandPlaceholderedGlob(pattern.path, resolveOverridenLocale(sourceLocale, pattern.delimiter)).map(
+    expandPlaceholderedGlob(pattern.path, resolveOverriddenLocale(sourceLocale, pattern.delimiter)).map(
       (pathPattern) => ({
         pathPattern,
         delimiter: pattern.delimiter,

--- a/packages/spec/src/locales.ts
+++ b/packages/spec/src/locales.ts
@@ -249,7 +249,7 @@ export const getLocaleCodeDelimiter = (locale: string): string | null => {
   }
 };
 
-export const resolveOverridenLocale = (locale: string, delimiter?: "-" | "_" | null): string => {
+export const resolveOverriddenLocale = (locale: string, delimiter?: "-" | "_" | null): string => {
   if (!delimiter) {
     return locale;
   }


### PR DESCRIPTION
## What does this PR do?
This PR fixes a typo in the function name `resolveOverridenLocale` by renaming it to `resolveOverriddenLocale`.

