### PR TITLE
fix: value.match is not a function with .po files

### DIFF
--- a/packages/cli/src/cli/loaders/variable/index.ts
+++ b/packages/cli/src/cli/loaders/variable/index.ts
@@ -25,6 +25,9 @@ function variableExtractLoader(
     pull: async (locale, input) => {
       const result: Record<string, VariableExtractionPayload> = {};
       for (const [key, value] of Object.entries(input)) {
+        if (typeof value !== "string") {
+          continue;
+        }
         const matches = value.match(specifierPattern) || [];
         result[key] = result[key] || {
           value,


### PR DESCRIPTION
this is just a quick and dirty workaround. to fix i18n --frozen not working with .po files.  see https://github.com/lingodotdev/lingo.dev/issues/592