### PR TITLE
feat(cli): inject locale code into locale files

### DIFF
--- a/.changeset/strange-insects-greet.md
+++ b/.changeset/strange-insects-greet.md
@@ -1,0 +1,6 @@
+---
+"@lingo.dev/_spec": patch
+"lingo.dev": patch
+---
+
+inject locale

--- a/packages/cli/src/cli/cmd/cleanup.ts
+++ b/packages/cli/src/cli/cmd/cleanup.ts
@@ -14,9 +14,10 @@ export default new Command()
   .option("--locale <locale>", "Specific locale to cleanup")
   .option("--bucket <bucket>", "Specific bucket to cleanup")
   .option("--dry-run", "Show what would be removed without making changes")
-  .option("--verbose", "Show detailed output including:\n" +
-                       "  - List of keys that would be removed.\n" +
-                       "  - Processing steps.")
+  .option(
+    "--verbose",
+    "Show detailed output including:\n" + "  - List of keys that would be removed.\n" + "  - Processing steps.",
+  )
   .action(async function (options) {
     const ora = Ora();
     const results: any = [];
@@ -39,7 +40,7 @@ export default new Command()
         console.log();
         ora.info(`Processing bucket: ${bucket.type}`);
 
-        for (const bucketConfig of bucket.config) {
+        for (const bucketConfig of bucket.paths) {
           const sourceLocale = resolveOverriddenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
           const bucketOra = Ora({ indent: 2 }).info(`Processing path: ${bucketConfig.pathPattern}`);
           const bucketLoader = createBucketLoader(bucket.type, bucketConfig.pathPattern, {

--- a/packages/cli/src/cli/cmd/lockfile.ts
+++ b/packages/cli/src/cli/cmd/lockfile.ts
@@ -24,7 +24,7 @@ export default new Command()
       const buckets = getBuckets(i18nConfig!);
 
       for (const bucket of buckets) {
-        for (const bucketConfig of bucket.config) {
+        for (const bucketConfig of bucket.paths) {
           const sourceLocale = resolveOverriddenLocale(i18nConfig!.locale.source, bucketConfig.delimiter);
           const bucketLoader = createBucketLoader(bucket.type, bucketConfig.pathPattern, {
             isCacheRestore: false,

--- a/packages/cli/src/cli/cmd/show/files.ts
+++ b/packages/cli/src/cli/cmd/show/files.ts
@@ -27,7 +27,7 @@ export default new Command()
 
         const buckets = getBuckets(i18nConfig);
         for (const bucket of buckets) {
-          for (const bucketConfig of bucket.config) {
+          for (const bucketConfig of bucket.paths) {
             const sourceLocale = resolveOverriddenLocale(i18nConfig.locale.source, bucketConfig.delimiter);
             const sourcePath = bucketConfig.pathPattern.replace(/\[locale\]/g, sourceLocale);
             const targetPaths = i18nConfig.locale.targets.map((_targetLocale) => {

--- a/packages/cli/src/cli/loaders/index.ts
+++ b/packages/cli/src/cli/loaders/index.ts
@@ -29,11 +29,13 @@ import createSyncLoader from "./sync";
 import createPlutilJsonTextLoader from "./plutil-json-loader";
 import createPhpLoader from "./php";
 import createVueJsonLoader from "./vue-json";
+import createInjectLocaleLoader from "./inject-locale";
 
 type BucketLoaderOptions = {
   isCacheRestore: boolean;
   returnUnlocalizedKeys?: boolean;
   defaultLocale: string;
+  injectLocale?: string[];
 };
 
 export default function createBucketLoader(
@@ -73,6 +75,7 @@ export default function createBucketLoader(
         createTextFileLoader(bucketPathPattern),
         createPrettierLoader({ parser: "json", bucketPathPattern }),
         createJsonLoader(),
+        createInjectLocaleLoader(options.injectLocale),
         createFlatLoader(),
         createSyncLoader(),
         createUnlocalizableLoader(options.isCacheRestore, options.returnUnlocalizedKeys),

--- a/packages/cli/src/cli/loaders/inject-locale.ts
+++ b/packages/cli/src/cli/loaders/inject-locale.ts
@@ -1,0 +1,31 @@
+import _ from "lodash";
+import { ILoader } from "./_types";
+import { createLoader } from "./_utils";
+
+export default function createInjectLocaleLoader(
+  injectLocaleKeys?: string[],
+): ILoader<Record<string, any>, Record<string, any>> {
+  return createLoader({
+    async pull(locale, data) {
+      if (!injectLocaleKeys) {
+        return data;
+      }
+      const omitKeys = injectLocaleKeys.filter((key) => {
+        return _.get(data, key) === locale;
+      });
+      const result = _.omit(data, omitKeys);
+      return result;
+    },
+    async push(locale, data, originalInput, originalLocale) {
+      if (!injectLocaleKeys) {
+        return data;
+      }
+      injectLocaleKeys.forEach((key) => {
+        if (_.get(originalInput, key) === originalLocale) {
+          _.set(data, key, locale);
+        }
+      });
+      return data;
+    },
+  });
+}

--- a/packages/cli/src/cli/utils/buckets.spec.ts
+++ b/packages/cli/src/cli/utils/buckets.spec.ts
@@ -31,7 +31,7 @@ describe("getBuckets", () => {
     expect(buckets).toEqual([
       {
         type: "json",
-        config: [
+        paths: [
           { pathPattern: "src/i18n/[locale].json", delimiter: null },
           { pathPattern: "src/translations/[locale]/messages.json", delimiter: null },
         ],
@@ -61,7 +61,7 @@ describe("getBuckets", () => {
     expect(buckets).toEqual([
       {
         type: "json",
-        config: [
+        paths: [
           { pathPattern: "src/translations/landing.[locale].json", delimiter: null },
           { pathPattern: "src/translations/app.[locale].json", delimiter: null },
           { pathPattern: "src/translations/email.[locale].json", delimiter: null },
@@ -83,7 +83,7 @@ describe("getBuckets", () => {
     mockGlobSync(["src/i18n/en.json"]);
     const i18nConfig = makeI18nConfig([{ path: "src/i18n/[locale].json", delimiter: "-" }]);
     const buckets = getBuckets(i18nConfig);
-    expect(buckets).toEqual([{ type: "json", config: [{ pathPattern: "src/i18n/[locale].json", delimiter: "-" }] }]);
+    expect(buckets).toEqual([{ type: "json", paths: [{ pathPattern: "src/i18n/[locale].json", delimiter: "-" }] }]);
   });
 
   it("should return bucket with multiple locale placeholders", () => {
@@ -96,7 +96,7 @@ describe("getBuckets", () => {
     expect(buckets).toEqual([
       {
         type: "json",
-        config: [
+        paths: [
           { pathPattern: "src/i18n/[locale]/[locale].json", delimiter: null },
           { pathPattern: "src/[locale]/translations/[locale]/messages.json", delimiter: null },
         ],

--- a/packages/spec/src/config.ts
+++ b/packages/spec/src/config.ts
@@ -23,12 +23,12 @@ type ConfigDefinitionExtensionParams<T extends Z.ZodRawShape, P extends Z.ZodRaw
   createUpgrader: (
     config: Z.infer<Z.ZodObject<P>>,
     schema: Z.ZodObject<T>,
-    defaultValue: Z.infer<Z.ZodObject<T>>,
+    defaultValue: Z.infer<Z.ZodObject<T>>
   ) => Z.infer<Z.ZodObject<T>>;
 };
 const extendConfigDefinition = <T extends Z.ZodRawShape, P extends Z.ZodRawShape>(
   definition: ConfigDefinition<P, any>,
-  params: ConfigDefinitionExtensionParams<T, P>,
+  params: ConfigDefinitionExtensionParams<T, P>
 ) => {
   const schema = params.createSchema(definition.schema);
   const defaultValue = params.createDefaultValue(definition.defaultValue);
@@ -120,7 +120,7 @@ export const configV1_1Definition = extendConfigDefinition(configV1Definition, {
         Z.object({
           include: Z.array(Z.string()).default([]),
           exclude: Z.array(Z.string()).default([]).optional(),
-        }),
+        })
       ).default({}),
     }),
   createDefaultValue: (baseDefaultValue) => ({
@@ -187,7 +187,8 @@ export const configV1_3Definition = extendConfigDefinition(configV1_2Definition,
           exclude: Z.array(Z.union([Z.string(), bucketItemSchema]))
             .default([])
             .optional(),
-        }),
+          injectLocale: Z.array(Z.string()).optional(),
+        })
       ).default({}),
     }),
   createDefaultValue: (baseDefaultValue) => ({


### PR DESCRIPTION
Add array of keys as "injectLocale" to JSON bucket config.

Example:

```json
{
  "version": 1.4,
  "locale": {
    "source": "en",
    "targets": [
      "es", 
      "sk"
    ]
  },
  "buckets": {
    "json": {
      "include": [
        "locales/[locale].json"
      ],
      "injectLocale": [
        "settings.locale",
        "language"
      ]
    }
  },
  "$schema": "https://lingo.dev/schema/i18n.json"
}
```

This config will replace `settings.locale` and `langauge` values with `es` and `sk` values if the original value in source file was `en`.