### PR TITLE
feat(cli): support bun package manager

### DIFF
--- a/.changeset/calm-mugs-cheat.md
+++ b/.changeset/calm-mugs-cheat.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+support bun package manager

--- a/packages/cli/src/cli/loaders/prettier.ts
+++ b/packages/cli/src/cli/loaders/prettier.ts
@@ -83,12 +83,19 @@ async function installDependencies() {
 // determine if yarn or pnpm is used based on lockfile, otherwise use npm
 async function getPackageManager() {
   const yarnLockfile = path.resolve(process.cwd(), "yarn.lock");
-  const pnpmLockfile = path.resolve(process.cwd(), "pnpm-lock.yaml");
   if (fs.existsSync(yarnLockfile)) {
     return "yarn";
   }
+
+  const pnpmLockfile = path.resolve(process.cwd(), "pnpm-lock.yaml");
   if (fs.existsSync(pnpmLockfile)) {
     return "pnpm";
   }
+
+  const bunLockfile = path.resolve(process.cwd(), "bun.lock");
+  if (fs.existsSync(bunLockfile)) {
+    return "bun";
+  }
+
   return "npm";
 }


### PR DESCRIPTION
When installing prettier plugins, use `bun` package manager if project uses it (https://bun.sh/).