### PR TITLE
fix(cli): added jsonrepair and trimming in explicit.ts

### DIFF
--- a/packages/cli/src/cli/localizer/explicit.ts
+++ b/packages/cli/src/cli/localizer/explicit.ts
@@ -6,6 +6,7 @@ import dedent from "dedent";
 import { ILocalizer, LocalizerData } from "./_types";
 import { LanguageModel, Message, generateText } from "ai";
 import { colors } from "../constants";
+import { jsonrepair } from "jsonrepair";
 
 export default function createExplicitLocalizer(
   provider: NonNullable<I18nConfig["provider"]>,
@@ -135,8 +136,13 @@ function createAiSdkLocalizer(params: {
       });
 
       const result = JSON.parse(response.text);
+      const index = result.data.indexOf("{");
+      const lastIndex = result.data.lastIndexOf("}");
+      const trimmed = result.data.slice(index, lastIndex + 1);
+      const repaired = jsonrepair(trimmed);
+      const finalResult = JSON.parse(repaired);
 
-      return result.data;
+      return finalResult;
     },
   };
 }


### PR DESCRIPTION
fix : Localization failed: Unexpected token

Summary: 
Should close https://github.com/lingodotdev/lingo.dev/issues/791

Added trimming logic to the json output of llm.
json is passed to jsonrepair library before returning the result

Notes:
there should be no error now incase LLM's provide a malformed response