### PR TITLE
feat: add georgian (ka-GE) locale support

### DIFF
--- a/.changeset/smart-cobras-appear.md
+++ b/.changeset/smart-cobras-appear.md
@@ -1,0 +1,5 @@
+---
+"@lingo.dev/_spec": patch
+---
+
+Introduce the gregorian language (ka-GE)

--- a/packages/spec/src/locales.spec.ts
+++ b/packages/spec/src/locales.spec.ts
@@ -68,9 +68,6 @@ describe("getLocaleCodeDelimiter", () => {
   it("should return undefined for locale codes without a recognized delimiter", () => {
     expect(getLocaleCodeDelimiter("enUS")).toBeNull();
     expect(getLocaleCodeDelimiter("frFR")).toBeNull();
-  });
-
-  it("should return undefined for locale codes without a recognized delimiter", () => {
     expect(getLocaleCodeDelimiter("kaGE")).toBeNull();
   });
 });

--- a/packages/spec/src/locales.spec.ts
+++ b/packages/spec/src/locales.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { getLocaleCodeDelimiter, normalizeLocale, resolveLocaleCode, resolveOverriddenLocale } from "./locales";
+import {
+  getLocaleCodeDelimiter,
+  normalizeLocale,
+  resolveLocaleCode,
+  resolveOverriddenLocale,
+} from "./locales";
 
 describe("normalizeLocale", () => {
   it("should return normalized locale for short locale codes", () => {
@@ -63,6 +68,10 @@ describe("getLocaleCodeDelimiter", () => {
   it("should return undefined for locale codes without a recognized delimiter", () => {
     expect(getLocaleCodeDelimiter("enUS")).toBeNull();
     expect(getLocaleCodeDelimiter("frFR")).toBeNull();
+  });
+
+  it("should return undefined for locale codes without a recognized delimiter", () => {
+    expect(getLocaleCodeDelimiter("kaGE")).toBeNull();
   });
 });
 

--- a/packages/spec/src/locales.ts
+++ b/packages/spec/src/locales.ts
@@ -200,6 +200,8 @@ const localeMap = {
   te: ["te-IN"],
   // Kinyarwanda (Rwanda)
   rw: ["rw-RW"],
+  // Georgian (Georgia)
+  ka: ["ka"],
 } as const;
 
 export type LocaleCodeShort = keyof typeof localeMap;
@@ -208,8 +210,12 @@ export type LocaleCode = LocaleCodeShort | LocaleCodeFull;
 export type LocaleDelimiter = "-" | "_" | null;
 
 export const localeCodesShort = Object.keys(localeMap) as LocaleCodeShort[];
-export const localeCodesFull = Object.values(localeMap).flat() as LocaleCodeFull[];
-export const localeCodesFullUnderscore = localeCodesFull.map((value) => value.replace("-", "_"));
+export const localeCodesFull = Object.values(
+  localeMap,
+).flat() as LocaleCodeFull[];
+export const localeCodesFullUnderscore = localeCodesFull.map((value) =>
+  value.replace("-", "_"),
+);
 export const localeCodesFullExplicitRegion = localeCodesFull.map((value) => {
   const chunks = value.split("-");
   const result = [chunks[0], "-r", chunks.slice(1).join("-")].join("");
@@ -222,9 +228,12 @@ export const localeCodes = [
   ...localeCodesFullExplicitRegion,
 ] as LocaleCode[];
 
-export const localeCodeSchema = Z.string().refine((value) => localeCodes.includes(value as any), {
-  message: "Invalid locale code",
-});
+export const localeCodeSchema = Z.string().refine(
+  (value) => localeCodes.includes(value as any),
+  {
+    message: "Invalid locale code",
+  },
+);
 
 /**
  * Resolves a locale code to its full locale representation.
@@ -280,7 +289,10 @@ export const getLocaleCodeDelimiter = (locale: string): LocaleDelimiter => {
  * @returns {string} The locale string with the replaced delimiter, or the original locale if no delimiter is provided.
  */
 
-export const resolveOverriddenLocale = (locale: string, delimiter?: LocaleDelimiter): string => {
+export const resolveOverriddenLocale = (
+  locale: string,
+  delimiter?: LocaleDelimiter,
+): string => {
   if (!delimiter) {
     return locale;
   }

--- a/packages/spec/src/locales.ts
+++ b/packages/spec/src/locales.ts
@@ -201,7 +201,7 @@ const localeMap = {
   // Kinyarwanda (Rwanda)
   rw: ["rw-RW"],
   // Georgian (Georgia)
-  ka: ["ka"],
+  ka: ["ka-GE"],
 } as const;
 
 export type LocaleCodeShort = keyof typeof localeMap;


### PR DESCRIPTION
## What Changed

- **Added Georgian (ka-GE) locale support:**
  - Extended `localeMap` in `packages/spec/src/locales.ts` to include Georgian locale
  - Added corresponding test case in `packages/spec/src/locales.spec.ts` for `getLocaleCodeDelimiter`

## Additional Information

- Closes #750 
- No breaking changes introduced
- All tests are passing with the new locale addition
- As I talked with @maxprilutskiy on X (Twitter) seems like this is the first step for the API to have support for the Gregorian Language