### PR TITLE
feat(cli/csv): improve `csv` loader

### DIFF
--- a/.changeset/funny-cars-confess.md
+++ b/.changeset/funny-cars-confess.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": minor
+---
+
+Reduce duplicated parsing and more dynamic key column naming support

--- a/packages/cli/demo/csv/file.csv
+++ b/packages/cli/demo/csv/file.csv
@@ -1,3 +1,3 @@
-id,en,es,ru
+KEY,en,es,ru
 dashboard.title,Dashboard,Panel de control,Панель управления
 greeting.message,Hello world!,¡Hola mundo!,"Привет, мир!"

--- a/packages/cli/src/cli/loaders/csv.ts
+++ b/packages/cli/src/cli/loaders/csv.ts
@@ -33,7 +33,7 @@ export default function createCsvLoader(): ILoader<
         if (detectedKeyColumnName) return detectedKeyColumnName;
 
         for (const key of ["KEY", "key"]) {
-          if (inputParsed.some((row) => row[key])) {
+          if (inputParsed[0][key]) {
             // console.debug(`Detected key column name from preferred keys: ${key}`);
             return keyColumnName = detectedKeyColumnName = key;
           }

--- a/packages/cli/src/cli/loaders/csv.ts
+++ b/packages/cli/src/cli/loaders/csv.ts
@@ -8,18 +8,47 @@ export default function createCsvLoader(): ILoader<
   string,
   Record<string, string>
 > {
+  let inputParsed: Record<string, any>[];
+  let keyColumnName: string = "KEY";
+  let detectedKeyColumnName: string | null = null;
+
   return createLoader({
-    async pull(locale, _input) {
-      const input = parse(_input, {
+    async pull(locale, input) {
+      inputParsed = parse(input, {
         columns: true,
         skip_empty_lines: true,
         relax_column_count_less: true,
-      });
+      }) as Record<string, any>[];
 
       const result: Record<string, string> = {};
 
-      _.forEach(input, (row) => {
-        const key = row.id;
+      /**
+       * Tries to detect the key column name
+       *
+       * Current detect logics and orders:
+       * + known preferred keys
+       * + first non-empty cell
+       */
+      function _detectKeyColumnName() {
+        if (detectedKeyColumnName) return detectedKeyColumnName;
+
+        for (const key of ["KEY", "key"]) {
+          if (inputParsed.some((row) => row[key])) {
+            // console.debug(`Detected key column name from preferred keys: ${key}`);
+            return keyColumnName = detectedKeyColumnName = key;
+          }
+        }
+
+        const firstContentfulRow = parse(input.split('\n').find(l => l.length)!)[0];
+        const firstContentfulColumn = firstContentfulRow.find(Boolean)
+        if (firstContentfulColumn) {
+          // console.debug(`Detected key column name from first non-empty cell: ${firstContentfulColumn}`);
+          return keyColumnName = detectedKeyColumnName = firstContentfulColumn;
+        }
+      }
+
+      _.forEach(inputParsed, (row) => {
+        const key = row[_detectKeyColumnName()];
         if (key && row[locale] && row[locale].trim() !== "") {
           result[key] = row[locale];
         }
@@ -27,28 +56,22 @@ export default function createCsvLoader(): ILoader<
 
       return result;
     },
-    async push(locale, data, originalInput) {
-      const input = parse(originalInput || "", {
-        columns: true,
-        skip_empty_lines: true,
-        relax_column_count_less: true,
-      }) as Record<string, any>[];
-
-      const columns = input.length > 0 ? Object.keys(input[0]) : ["id", locale];
+    async push(locale, data) {
+      const columns = inputParsed.length > 0 ? Object.keys(inputParsed[0]) : [keyColumnName, locale];
       if (!columns.includes(locale)) {
         columns.push(locale);
       }
 
-      const updatedRows = input.map((row) => ({
+      const updatedRows = inputParsed.map((row) => ({
         ...row,
-        [locale]: data[row.id] || row[locale] || "",
+        [locale]: data[row[keyColumnName]] || row[locale] || "",
       }));
-      const existingKeys = new Set(input.map((row) => row.id));
+      const existingKeys = new Set(inputParsed.map((row) => row[keyColumnName]));
 
       Object.entries(data).forEach(([key, value]) => {
         if (!existingKeys.has(key)) {
           const newRow: Record<string, string> = {
-            id: key,
+            [keyColumnName]: key,
             ...Object.fromEntries(columns.map((column) => [column, ""])),
           };
           newRow[locale] = value;

--- a/packages/cli/src/cli/loaders/csv.ts
+++ b/packages/cli/src/cli/loaders/csv.ts
@@ -7,12 +7,12 @@ import { createLoader } from "./_utils";
 /**
  * Tries to detect the key column name from a csvString.
  * 
- * Current logic: get first non-empty cell > 'KEY' fallback
+ * Current logic: get first cell > 'KEY' fallback if empty
  */
 export function detectKeyColumnName(csvString: string) {
   const row: string[] | undefined = parse(csvString)[0];
-  const firstContentfulColumn = row?.find((v: string) => v.trim() !== "");
-  return firstContentfulColumn ?? "KEY";
+  const firstColumn = row?.[0]?.trim();
+  return firstColumn || "KEY";
 }
 
 export default function createCsvLoader(): ILoader<

--- a/packages/cli/src/cli/loaders/csv.ts
+++ b/packages/cli/src/cli/loaders/csv.ts
@@ -2,7 +2,7 @@ import { parse } from "csv-parse/sync";
 import { stringify } from "csv-stringify/sync";
 import _ from "lodash";
 import { ILoader } from "./_types";
-import { createLoader } from "./_utils";
+import { composeLoaders, createLoader } from "./_utils";
 
 /**
  * Tries to detect the key column name from a csvString.
@@ -15,35 +15,46 @@ export function detectKeyColumnName(csvString: string) {
   return firstColumn || "KEY";
 }
 
-export default function createCsvLoader(): ILoader<
-  string,
-  Record<string, string>
-> {
-  let inputParsed: Record<string, any>[];
-  let keyColumnName: string = "KEY";
+export default function createCsvLoader() {
+  return composeLoaders(_createCsvLoader(), createPullOutputCleaner())
+}
 
+type InternalTransferState = {
+  keyColumnName: string;
+  inputParsed: Record<string, any>[];
+  items: Record<string, string>;
+}
+
+function _createCsvLoader(): ILoader<
+  string,
+  InternalTransferState
+> {
   return createLoader({
     async pull(locale, input) {
-      inputParsed = parse(input, {
+      const keyColumnName = detectKeyColumnName(input.split('\n').find(l => l.length)!);
+      const inputParsed = parse(input, {
         columns: true,
         skip_empty_lines: true,
         relax_column_count_less: true,
       }) as Record<string, any>[];
 
-      keyColumnName = detectKeyColumnName(input.split('\n').find(l => l.length)!);
-
-      const result: Record<string, string> = {};
-
+      const items: Record<string, string> = {};
+      
+      // Assign keys that already have translation so AI doesn't re-generate it.
       _.forEach(inputParsed, (row) => {
         const key = row[keyColumnName];
         if (key && row[locale] && row[locale].trim() !== "") {
-          result[key] = row[locale];
+          items[key] = row[locale];
         }
       });
 
-      return result;
+      return {
+        inputParsed,
+        keyColumnName,
+        items
+      };
     },
-    async push(locale, data) {
+    async push(locale, {inputParsed, keyColumnName, items}) {
       const columns = inputParsed.length > 0 ? Object.keys(inputParsed[0]) : [keyColumnName, locale];
       if (!columns.includes(locale)) {
         columns.push(locale);
@@ -51,11 +62,11 @@ export default function createCsvLoader(): ILoader<
 
       const updatedRows = inputParsed.map((row) => ({
         ...row,
-        [locale]: data[row[keyColumnName]] || row[locale] || "",
+        [locale]: items[row[keyColumnName]] || row[locale] || "",
       }));
       const existingKeys = new Set(inputParsed.map((row) => row[keyColumnName]));
 
-      Object.entries(data).forEach(([key, value]) => {
+      Object.entries(items).forEach(([key, value]) => {
         if (!existingKeys.has(key)) {
           const newRow: Record<string, string> = {
             [keyColumnName]: key,
@@ -70,6 +81,23 @@ export default function createCsvLoader(): ILoader<
         header: true,
         columns,
       });
+    },
+  });
+}
+
+/**
+ * This is a simple extra loader that is used to clean the data written to lockfile
+ */
+function createPullOutputCleaner(): ILoader<
+  InternalTransferState,
+  Record<string, string>
+> {
+  return createLoader({
+    async pull(_locale, input) {
+      return input.items;
+    },
+    async push(_locale, data, _oI, _oL, pullInput) {
+      return { ...pullInput!, items:data };
     },
   });
 }

--- a/packages/cli/src/cli/loaders/csv.ts
+++ b/packages/cli/src/cli/loaders/csv.ts
@@ -39,7 +39,7 @@ function _createCsvLoader(): ILoader<
       }) as Record<string, any>[];
 
       const items: Record<string, string> = {};
-      
+
       // Assign keys that already have translation so AI doesn't re-generate it.
       _.forEach(inputParsed, (row) => {
         const key = row[keyColumnName];
@@ -54,7 +54,7 @@ function _createCsvLoader(): ILoader<
         items
       };
     },
-    async push(locale, {inputParsed, keyColumnName, items}) {
+    async push(locale, { inputParsed, keyColumnName, items }) {
       const columns = inputParsed.length > 0 ? Object.keys(inputParsed[0]) : [keyColumnName, locale];
       if (!columns.includes(locale)) {
         columns.push(locale);
@@ -97,7 +97,7 @@ function createPullOutputCleaner(): ILoader<
       return input.items;
     },
     async push(_locale, data, _oI, _oL, pullInput) {
-      return { ...pullInput!, items:data };
+      return { ...pullInput!, items: data };
     },
   });
 }

--- a/packages/cli/src/cli/loaders/index.spec.ts
+++ b/packages/cli/src/cli/loaders/index.spec.ts
@@ -104,7 +104,7 @@ describe("bucket loaders", () => {
   });
 
   describe("csv bucket loader", () => {
-    it("should load csv data ('KEY' as key, second cell (first is empty))", async () => {
+    it("should load csv data ('KEY' as key, from automatic fallback", async () => {
       setupFileMocks();
 
       const input = ` ,KEY,en\n,button.title,Submit`;

--- a/packages/cli/src/cli/loaders/index.spec.ts
+++ b/packages/cli/src/cli/loaders/index.spec.ts
@@ -104,10 +104,10 @@ describe("bucket loaders", () => {
   });
 
   describe("csv bucket loader", () => {
-    it("should load csv data ('KEY' as key, preferred, second column)", async () => {
+    it("should load csv data ('KEY' as key, second cell (first is empty))", async () => {
       setupFileMocks();
 
-      const input = `dummyKey,KEY,en\ndummyValue,button.title,Submit`;
+      const input = ` ,KEY,en\n,button.title,Submit`;
       const expectedOutput = { "button.title": "Submit" };
 
       mockFileOperations(input);
@@ -122,7 +122,7 @@ describe("bucket loaders", () => {
       expect(data).toEqual(expectedOutput);
     });
 
-    it("should load csv data ('id' as key, inferred from first cell)", async () => {
+    it("should load csv data ('id' as key, first cell)", async () => {
       setupFileMocks();
 
       const input = `id,en\nbutton.title,Submit`;

--- a/packages/cli/src/cli/loaders/index.spec.ts
+++ b/packages/cli/src/cli/loaders/index.spec.ts
@@ -104,7 +104,25 @@ describe("bucket loaders", () => {
   });
 
   describe("csv bucket loader", () => {
-    it("should load csv data", async () => {
+    it("should load csv data ('KEY' as key, preferred, second column)", async () => {
+      setupFileMocks();
+
+      const input = `dummyKey,KEY,en\ndummyValue,button.title,Submit`;
+      const expectedOutput = { "button.title": "Submit" };
+
+      mockFileOperations(input);
+
+      const csvLoader = createBucketLoader("csv", "i18n.csv", {
+        isCacheRestore: false,
+        defaultLocale: "en",
+      });
+      csvLoader.setDefaultLocale("en");
+      const data = await csvLoader.pull("en");
+
+      expect(data).toEqual(expectedOutput);
+    });
+
+    it("should load csv data ('id' as key, inferred from first cell)", async () => {
       setupFileMocks();
 
       const input = `id,en\nbutton.title,Submit`;


### PR DESCRIPTION
This PR is a set of changes for `csv` loader:
+ Reduce duplicated parsing
+ Dynamic key column naming support
  * Resolves #870

#### Implementation:

I added some variables like `inputParsed` to prevent parsing twice in both `pull` and `push`

I added a local function `_detectKeyColumnName()` to automatically detect the key column naming, current logics including: `known preferred keys` (`KEY`|`key`), `first non-empty cell`.

#### Additional Context:

At first I was working on another solution where I deprecate `id` (and still supports it for backward-compat), and prefers `KEY`, and adding a whole new option to set the `keyColumn`, but they requires too big of a change, I then followed @maxprilutskiy's suggestion of looking at `[0]`, its simpler and works too I guess, could be breaking for those who is using the old `id` naming in a non-first column, but intuitively there should be mostly none affected, safe for non-major?