### PR TITLE
fix(compiler): update Groq API error handling

### DIFF
--- a/.changeset/wise-camels-trade.md
+++ b/.changeset/wise-camels-trade.md
@@ -1,0 +1,6 @@
+---
+"@lingo.dev/_compiler": patch
+"lingo.dev": patch
+---
+
+update Groq API error handling


### PR DESCRIPTION
When there is an issue with Groq API (eg. invalid API key) it stops the process. This ensures any issues with possibly missing translations are caught early on.