### PR TITLE
fix(compiler): rm `@/` and `~/` path mappings

### DIFF
--- a/.changeset/silly-cows-own.md
+++ b/.changeset/silly-cows-own.md
@@ -1,0 +1,5 @@
+---
+"@lingo.dev/_compiler": patch
+---
+
+remove @/ path mapping in compiler

--- a/packages/compiler/src/_base.ts
+++ b/packages/compiler/src/_base.ts
@@ -21,7 +21,7 @@ export type CompilerInput = {
 
 export type CompilerPayload = CompilerInput & {
   ast: t.File;
-  fileKey: string;
+  relativeFilePath: string;
 };
 export type CompilerOutput = {
   code: string;

--- a/packages/compiler/src/_base.ts
+++ b/packages/compiler/src/_base.ts
@@ -14,14 +14,13 @@ export type CompilerParams = {
   models: Record<string, string>;
 };
 export type CompilerInput = {
-  fileKey: string;
+  relativeFilePath: string;
   code: string;
   params: CompilerParams;
 };
 
 export type CompilerPayload = CompilerInput & {
   ast: t.File;
-  relativeFilePath: string;
 };
 export type CompilerOutput = {
   code: string;

--- a/packages/compiler/src/_utils.ts
+++ b/packages/compiler/src/_utils.ts
@@ -1,0 +1,15 @@
+import path from "path";
+
+import { LCP_DICTIONARY_FILE_NAME } from "./_const";
+
+export type GetDictionaryPathParams = {
+  sourceRoot: string;
+  lingoDir: string;
+  relativeFilePath: string;
+};
+export const getDictionaryPath = (params: GetDictionaryPathParams) => {
+  return path.relative(
+    params.relativeFilePath,
+    path.resolve(params.sourceRoot, params.lingoDir, LCP_DICTIONARY_FILE_NAME),
+  );
+};

--- a/packages/compiler/src/client-dictionary-loader.ts
+++ b/packages/compiler/src/client-dictionary-loader.ts
@@ -1,25 +1,11 @@
-import path from "path";
 import { createCodeMutation } from "./_base";
-import { LCP_DICTIONARY_FILE_NAME, ModuleId } from "./_const";
+import { ModuleId } from "./_const";
 import { getOrCreateImport } from "./utils";
 import { findInvokations } from "./utils/invokations";
 import * as t from "@babel/types";
+import { getDictionaryPath } from "./_utils";
 
 export const clientDictionaryLoaderMutation = createCodeMutation((payload) => {
-  const lingoDir = path.resolve(
-    process.cwd(),
-    payload.params.sourceRoot,
-    payload.params.lingoDir,
-  );
-  const currentDir = path.dirname(
-    path.resolve(
-      process.cwd(),
-      payload.params.sourceRoot,
-      payload.relativeFilePath,
-    ),
-  );
-  const relativeLingoPath = path.relative(currentDir, lingoDir);
-
   const invokations = findInvokations(payload.ast, {
     moduleName: ModuleId.ReactClient,
     functionName: "loadDictionary",
@@ -40,6 +26,12 @@ export const clientDictionaryLoaderMutation = createCodeMutation((payload) => {
       invokation.callee.name = internalDictionaryLoader.importedName;
     }
 
+    const dictionaryPath = getDictionaryPath({
+      sourceRoot: payload.params.sourceRoot,
+      lingoDir: payload.params.lingoDir,
+      relativeFilePath: payload.relativeFilePath,
+    });
+
     // Create locale import map object
     const localeImportMap = t.objectExpression(
       allLocales.map((locale) =>
@@ -48,9 +40,7 @@ export const clientDictionaryLoaderMutation = createCodeMutation((payload) => {
           t.arrowFunctionExpression(
             [],
             t.callExpression(t.identifier("import"), [
-              t.stringLiteral(
-                `./${relativeLingoPath}/${LCP_DICTIONARY_FILE_NAME}?locale=${locale}`,
-              ),
+              t.stringLiteral(`${dictionaryPath}?locale=${locale}`),
             ]),
           ),
         ),

--- a/packages/compiler/src/client-dictionary-loader.ts
+++ b/packages/compiler/src/client-dictionary-loader.ts
@@ -12,7 +12,11 @@ export const clientDictionaryLoaderMutation = createCodeMutation((payload) => {
     payload.params.lingoDir,
   );
   const currentDir = path.dirname(
-    path.resolve(process.cwd(), payload.params.sourceRoot, payload.fileKey),
+    path.resolve(
+      process.cwd(),
+      payload.params.sourceRoot,
+      payload.relativeFilePath,
+    ),
   );
   const relativeLingoPath = path.relative(currentDir, lingoDir);
 

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -134,7 +134,7 @@ const unplugin = createUnplugin<Partial<typeof defaultParams> | undefined>(
           const result = _.chain({
             code,
             params,
-            fileKey: path
+            relativeFilePath: path
               .relative(path.resolve(process.cwd(), params.sourceRoot), id)
               .split(path.sep)
               .join("/"), // Always normalize for consistent dictionaries

--- a/packages/compiler/src/jsx-attribute-scope-inject.spec.ts
+++ b/packages/compiler/src/jsx-attribute-scope-inject.spec.ts
@@ -1,18 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { lingoJsxAttributeScopeInjectMutation } from "./jsx-attribute-scope-inject";
-import {
-  createPayload,
-  createOutput,
-  CompilerParams,
-  defaultParams,
-} from "./_base";
+import { createPayload, createOutput, defaultParams } from "./_base";
 import * as parser from "@babel/parser";
 import generate from "@babel/generator";
 
 // Helper function to run mutation and get result
 function runMutation(code: string, rsc = false) {
   const params = { ...defaultParams, rsc };
-  const input = createPayload({ code, params, fileKey: "test" });
+  const input = createPayload({ code, params, relativeFilePath: "test" });
   const mutated = lingoJsxAttributeScopeInjectMutation(input);
   if (!mutated) throw new Error("Mutation returned null");
   return createOutput(mutated).code;

--- a/packages/compiler/src/jsx-attribute-scope-inject.ts
+++ b/packages/compiler/src/jsx-attribute-scope-inject.ts
@@ -49,7 +49,7 @@ export const lingoJsxAttributeScopeInjectMutation = createCodeMutation(
       jsxScope.node.openingElement.attributes.push(
         t.jsxAttribute(
           t.jsxIdentifier("$fileKey"),
-          t.stringLiteral(payload.fileKey),
+          t.stringLiteral(payload.relativeFilePath),
         ),
       );
 

--- a/packages/compiler/src/jsx-attribute-scopes-export.ts
+++ b/packages/compiler/src/jsx-attribute-scopes-export.ts
@@ -23,23 +23,27 @@ export function jsxAttributeScopesExportMutation(
     for (const attributeDefinition of attributes) {
       const [attribute, scopeKey] = attributeDefinition.split(":");
 
-      lcp.resetScope(payload.fileKey, scopeKey);
+      lcp.resetScope(payload.relativeFilePath, scopeKey);
 
       const attributeValue = getJsxAttributeValue(scope, attribute);
       if (!attributeValue) {
         continue;
       }
 
-      lcp.setScopeType(payload.fileKey, scopeKey, "attribute");
+      lcp.setScopeType(payload.relativeFilePath, scopeKey, "attribute");
 
       const hash = getJsxAttributeValueHash(String(attributeValue));
-      lcp.setScopeHash(payload.fileKey, scopeKey, hash);
+      lcp.setScopeHash(payload.relativeFilePath, scopeKey, hash);
 
-      lcp.setScopeContext(payload.fileKey, scopeKey, "");
-      lcp.setScopeSkip(payload.fileKey, scopeKey, false);
-      lcp.setScopeOverrides(payload.fileKey, scopeKey, {});
+      lcp.setScopeContext(payload.relativeFilePath, scopeKey, "");
+      lcp.setScopeSkip(payload.relativeFilePath, scopeKey, false);
+      lcp.setScopeOverrides(payload.relativeFilePath, scopeKey, {});
 
-      lcp.setScopeContent(payload.fileKey, scopeKey, String(attributeValue));
+      lcp.setScopeContent(
+        payload.relativeFilePath,
+        scopeKey,
+        String(attributeValue),
+      );
     }
   }
 

--- a/packages/compiler/src/jsx-scope-inject.spec.ts
+++ b/packages/compiler/src/jsx-scope-inject.spec.ts
@@ -7,7 +7,7 @@ import generate from "@babel/generator";
 // Helper function to run mutation and get result
 function runMutation(code: string, rsc = false) {
   const params = { ...defaultParams, rsc };
-  const input = createPayload({ code, params, fileKey: "test" });
+  const input = createPayload({ code, params, relativeFilePath: "test" });
   const mutated = lingoJsxScopeInjectMutation(input);
   if (!mutated) throw new Error("Mutation returned null");
   return createOutput(mutated).code;

--- a/packages/compiler/src/jsx-scope-inject.ts
+++ b/packages/compiler/src/jsx-scope-inject.ts
@@ -48,7 +48,7 @@ export const lingoJsxScopeInjectMutation = createCodeMutation((payload) => {
     originalAttributes.push(
       t.jsxAttribute(
         t.jsxIdentifier("$fileKey"),
-        t.stringLiteral(payload.fileKey),
+        t.stringLiteral(payload.relativeFilePath),
       ),
     );
     // Add $entryKey prop

--- a/packages/compiler/src/jsx-scopes-export.ts
+++ b/packages/compiler/src/jsx-scopes-export.ts
@@ -25,18 +25,26 @@ export function jsxScopesExportMutation(
   for (const scope of scopes) {
     const scopeKey = getAstKey(scope);
 
-    lcp.resetScope(payload.fileKey, scopeKey);
+    lcp.resetScope(payload.relativeFilePath, scopeKey);
 
-    lcp.setScopeType(payload.fileKey, scopeKey, "element");
+    lcp.setScopeType(payload.relativeFilePath, scopeKey, "element");
 
     const hash = getJsxElementHash(scope);
-    lcp.setScopeHash(payload.fileKey, scopeKey, hash);
+    lcp.setScopeHash(payload.relativeFilePath, scopeKey, hash);
 
     const context = getJsxAttributeValue(scope, "data-lingo-context");
-    lcp.setScopeContext(payload.fileKey, scopeKey, String(context || ""));
+    lcp.setScopeContext(
+      payload.relativeFilePath,
+      scopeKey,
+      String(context || ""),
+    );
 
     const skip = getJsxAttributeValue(scope, "data-lingo-skip");
-    lcp.setScopeSkip(payload.fileKey, scopeKey, Boolean(skip || false));
+    lcp.setScopeSkip(
+      payload.relativeFilePath,
+      scopeKey,
+      Boolean(skip || false),
+    );
 
     const attributesMap = getJsxAttributesMap(scope);
     const overrides = _.chain(attributesMap)
@@ -49,10 +57,10 @@ export function jsxScopesExportMutation(
       .filter(([, v]) => !!v)
       .fromPairs()
       .value();
-    lcp.setScopeOverrides(payload.fileKey, scopeKey, overrides);
+    lcp.setScopeOverrides(payload.relativeFilePath, scopeKey, overrides);
 
     const content = extractJsxContent(scope);
-    lcp.setScopeContent(payload.fileKey, scopeKey, content);
+    lcp.setScopeContent(payload.relativeFilePath, scopeKey, content);
   }
 
   lcp.save();

--- a/packages/compiler/src/react-router-dictionary-loader.ts
+++ b/packages/compiler/src/react-router-dictionary-loader.ts
@@ -1,9 +1,9 @@
-import generate from "@babel/generator";
 import { createCodeMutation } from "./_base";
-import { LCP_DICTIONARY_FILE_NAME, ModuleId } from "./_const";
+import { ModuleId } from "./_const";
 import { getModuleExecutionMode, getOrCreateImport } from "./utils";
 import { findInvokations } from "./utils/invokations";
 import * as t from "@babel/types";
+import { getDictionaryPath } from "./_utils";
 
 export const reactRouterDictionaryLoaderMutation = createCodeMutation(
   (payload) => {
@@ -32,6 +32,12 @@ export const reactRouterDictionaryLoaderMutation = createCodeMutation(
         invokation.callee.name = internalDictionaryLoader.importedName;
       }
 
+      const dictionaryPath = getDictionaryPath({
+        sourceRoot: payload.params.sourceRoot,
+        lingoDir: payload.params.lingoDir,
+        relativeFilePath: payload.relativeFilePath,
+      });
+
       // Create locale import map object
       const localeImportMap = t.objectExpression(
         allLocales.map((locale) =>
@@ -40,9 +46,7 @@ export const reactRouterDictionaryLoaderMutation = createCodeMutation(
             t.arrowFunctionExpression(
               [],
               t.callExpression(t.identifier("import"), [
-                t.stringLiteral(
-                  `~/${payload.params.lingoDir}/${LCP_DICTIONARY_FILE_NAME}?locale=${locale}`,
-                ),
+                t.stringLiteral(`${dictionaryPath}?locale=${locale}`),
               ]),
             ),
           ),

--- a/packages/compiler/src/rsc-dictionary-loader.ts
+++ b/packages/compiler/src/rsc-dictionary-loader.ts
@@ -4,6 +4,7 @@ import { LCP_DICTIONARY_FILE_NAME, ModuleId } from "./_const";
 import { getModuleExecutionMode, getOrCreateImport } from "./utils";
 import { findInvokations } from "./utils/invokations";
 import * as t from "@babel/types";
+import { getDictionaryPath } from "./_utils";
 
 export const rscDictionaryLoaderMutation = createCodeMutation((payload) => {
   const mode = getModuleExecutionMode(payload.ast, payload.params.rsc);
@@ -31,14 +32,11 @@ export const rscDictionaryLoaderMutation = createCodeMutation((payload) => {
       invokation.callee.name = internalDictionaryLoader.importedName;
     }
 
-    const relativePath = path.relative(
-      payload.relativeFilePath,
-      path.resolve(
-        payload.params.sourceRoot,
-        payload.params.lingoDir,
-        LCP_DICTIONARY_FILE_NAME,
-      ),
-    );
+    const dictionaryPath = getDictionaryPath({
+      sourceRoot: payload.params.sourceRoot,
+      lingoDir: payload.params.lingoDir,
+      relativeFilePath: payload.relativeFilePath,
+    });
 
     // Create locale import map object
     const localeImportMap = t.objectExpression(
@@ -48,7 +46,7 @@ export const rscDictionaryLoaderMutation = createCodeMutation((payload) => {
           t.arrowFunctionExpression(
             [],
             t.callExpression(t.identifier("import"), [
-              t.stringLiteral(`${relativePath}?locale=${locale}`),
+              t.stringLiteral(`${dictionaryPath}?locale=${locale}`),
             ]),
           ),
         ),

--- a/packages/compiler/src/rsc-dictionary-loader.ts
+++ b/packages/compiler/src/rsc-dictionary-loader.ts
@@ -1,4 +1,4 @@
-import generate from "@babel/generator";
+import path from "path";
 import { createCodeMutation } from "./_base";
 import { LCP_DICTIONARY_FILE_NAME, ModuleId } from "./_const";
 import { getModuleExecutionMode, getOrCreateImport } from "./utils";
@@ -31,6 +31,15 @@ export const rscDictionaryLoaderMutation = createCodeMutation((payload) => {
       invokation.callee.name = internalDictionaryLoader.importedName;
     }
 
+    const relativePath = path.relative(
+      payload.fileKey,
+      path.resolve(
+        payload.params.sourceRoot,
+        payload.params.lingoDir,
+        LCP_DICTIONARY_FILE_NAME,
+      ),
+    );
+
     // Create locale import map object
     const localeImportMap = t.objectExpression(
       allLocales.map((locale) =>
@@ -39,9 +48,7 @@ export const rscDictionaryLoaderMutation = createCodeMutation((payload) => {
           t.arrowFunctionExpression(
             [],
             t.callExpression(t.identifier("import"), [
-              t.stringLiteral(
-                `@/${payload.params.lingoDir}/${LCP_DICTIONARY_FILE_NAME}?locale=${locale}`,
-              ),
+              t.stringLiteral(`${relativePath}?locale=${locale}`),
             ]),
           ),
         ),

--- a/packages/compiler/src/rsc-dictionary-loader.ts
+++ b/packages/compiler/src/rsc-dictionary-loader.ts
@@ -32,7 +32,7 @@ export const rscDictionaryLoaderMutation = createCodeMutation((payload) => {
     }
 
     const relativePath = path.relative(
-      payload.fileKey,
+      payload.relativeFilePath,
       path.resolve(
         payload.params.sourceRoot,
         payload.params.lingoDir,


### PR DESCRIPTION
* inject relative paths instead of `@/` mapped paths
* renamed `fileKey` to be `relativeFilePath` as a hint that the field is expected to contain a relative path