### PR TITLE
feat(locales): add `ta-SG`, `en-SG`, and `zh-SG` locales for Singaporean region

### DIFF
--- a/packages/spec/src/locales.ts
+++ b/packages/spec/src/locales.ts
@@ -8,7 +8,10 @@ const localeMap = {
   // Turkish (Turkey)
   tr: ["tr-TR"],
   // Tamil (India)
-  ta: ["ta-IN"],
+  ta: [
+    "ta-IN", // India
+    "ta-SG", // Singapore
+  ],
   // Serbian
   sr: [
     "sr-RS", // Serbian (Latin)
@@ -37,6 +40,7 @@ const localeMap = {
     "en-GB", // United Kingdom
     "en-AU", // Australia
     "en-CA", // Canada
+    "en-SG", // Singapore
   ],
   // Spanish
   es: [
@@ -89,6 +93,7 @@ const localeMap = {
     "zh-CN", // Simplified Chinese (China)
     "zh-TW", // Traditional Chinese (Taiwan)
     "zh-HK", // Traditional Chinese (Hong Kong)
+    "zh-SG", // Simplified Chinese (Singapore)
     "zh-Hans", // Simplified Chinese
     "zh-Hant", // Traditional Chinese
     "zh-Hant-HK", // Traditional Chinese (Hong Kong)


### PR DESCRIPTION
## Changelog

### 🚀 Enhancements

- **locales:** Add `ta-SG`, `en-SG`, and `zh-SG` locales for Singaporean translation 

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/970844e0-6bdb-433a-840f-180f52ce687d" />

Ref: https://simplelocalize.io/data/locales/

Fix #884 