### PR TITLE
fix(cli): normalize paths and improve compatibility on windows

### DIFF
--- a/.changeset/breezy-pumas-fix.md
+++ b/.changeset/breezy-pumas-fix.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+normalize paths and improve compatibility on windows

--- a/packages/cli/src/cli/utils/buckets.ts
+++ b/packages/cli/src/cli/utils/buckets.ts
@@ -87,6 +87,13 @@ function extractPathPatterns(
   return result;
 }
 
+// Windows path normalization helper function
+function normalizePath(filepath: string): string {
+  const normalized = path.normalize(filepath);
+  // Ensure case consistency on Windows
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
 // Path expansion
 function expandPlaceholderedGlob(
   _pathPattern: string,
@@ -95,23 +102,27 @@ function expandPlaceholderedGlob(
   // Throw if pathPattern is an absolute path
   const absolutePathPattern = path.resolve(_pathPattern);
   const pathPattern = path.relative(process.cwd(), absolutePathPattern);
-  // Throw if pathPattern points outside the current working directory
-  if (path.relative(process.cwd(), pathPattern).startsWith("..")) {
+  // Normalize path for platform compatibility
+  const normalizedPathPattern = path.normalize(pathPattern);
+
+  const relativePattern = path.relative(process.cwd(), normalizePath(normalizedPathPattern));
+  if (relativePattern.startsWith("..")) {
     throw new CLIError({
-      message: `Invalid path pattern: ${pathPattern}. Path pattern must be within the current working directory.`,
+      message: `Invalid path pattern: ${normalizedPathPattern}. Path pattern must be within the current working directory.`,
       docUrl: "invalidPathPattern",
     });
   }
+
   // Throw error if pathPattern contains "**" – we don't support recursive path patterns
-  if (pathPattern.includes("**")) {
+  if (normalizedPathPattern.includes("**")) {
     throw new CLIError({
-      message: `Invalid path pattern: ${pathPattern}. Recursive path patterns are not supported.`,
+      message: `Invalid path pattern: ${normalizedPathPattern}. Recursive path patterns are not supported.`,
       docUrl: "invalidPathPattern",
     });
   }
 
   // Break down path pattern into parts
-  const pathPatternChunks = pathPattern.split(path.sep);
+  const pathPatternChunks = normalizedPathPattern.split(path.sep);
   // Find the index of the segment containing "[locale]"
   const localeSegmentIndexes = pathPatternChunks.reduce(
     (indexes, segment, index) => {
@@ -123,27 +134,37 @@ function expandPlaceholderedGlob(
     [] as number[],
   );
   // substitute [locale] in pathPattern with sourceLocale
-  const sourcePathPattern = pathPattern.replaceAll(/\[locale\]/g, sourceLocale);
+  const sourcePathPattern = normalizedPathPattern.replaceAll(/\[locale\]/g, sourceLocale);
+  // Convert to Unix-style for Windows compatibility
+  const unixStylePattern = sourcePathPattern.replace(/\\/g, '/');
+
   // get all files that match the sourcePathPattern
   const sourcePaths = glob
-    .sync(sourcePathPattern, { follow: true, withFileTypes: true })
+    .sync(unixStylePattern, {
+      follow: true,
+      withFileTypes: true,
+      windowsPathsNoEscape: true  // Windows path support
+    })
     .filter((file) => file.isFile() || file.isSymbolicLink())
     .map((file) => file.fullpath())
-    .map((fullpath) => path.relative(process.cwd(), fullpath));
+    .map((fullpath) => path.normalize(path.relative(process.cwd(), fullpath)));
+
   // transform each source file path back to [locale] placeholder paths
   const placeholderedPaths = sourcePaths.map((sourcePath) => {
-    const sourcePathChunks = sourcePath.split(path.sep);
+    // Normalize path returned by glob for platform compatibility
+    const normalizedSourcePath = path.normalize(sourcePath.replace(/\//g, path.sep));
+    const sourcePathChunks = normalizedSourcePath.split(path.sep);
     localeSegmentIndexes.forEach((localeSegmentIndex) => {
       // Find the position of the "[locale]" placeholder within the segment
       const pathPatternChunk = pathPatternChunks[localeSegmentIndex];
       const sourcePathChunk = sourcePathChunks[localeSegmentIndex];
       const regexp = new RegExp(
         "(" +
-          pathPatternChunk
-            .replaceAll(".", "\\.")
-            .replaceAll("*", ".*")
-            .replace("[locale]", `)${sourceLocale}(`) +
-          ")",
+        pathPatternChunk
+          .replaceAll(".", "\\.")
+          .replaceAll("*", ".*")
+          .replace("[locale]", `)${sourceLocale}(`) +
+        ")",
       );
       const match = sourcePathChunk.match(regexp);
       if (match) {


### PR DESCRIPTION
This PR fixes an issue where lingo.dev status and lingo.dev run could not correctly resolve file paths on Windows environments.


- Add helper function for path normalization on Windows platform
- Use normalized paths when validating path patterns
- Convert glob patterns to Unix-style for Windows compatibility
- Normalize returned paths to ensure cross-platform compatibility

discord thread: https://discord.com/channels/1193198600298172486/1382888601494356048