### PR TITLE
fix(compiler): fix remove whitespaces from inside the element

### DIFF
--- a/.changeset/large-zoos-explain.md
+++ b/.changeset/large-zoos-explain.md
@@ -1,0 +1,10 @@
+---
+"@lingo.dev/_compiler": minor
+---
+
+### Whitespace Normalization Fix
+
+- Improved `normalizeJsxWhitespace` logic to preserve leading spaces inside JSX elements while removing unnecessary formatting whitespace and extra lines.
+- Ensured explicit whitespace (e.g., `{" "}`) is handled correctly without introducing double spaces.
+- Added targeted tests (`jsx-content-whitespace.spec.ts`) to verify whitespace handling.
+- Cleaned up unnecessary debug/test files created during development.

--- a/packages/compiler/src/utils/jsx-content-whitespace.spec.ts
+++ b/packages/compiler/src/utils/jsx-content-whitespace.spec.ts
@@ -66,4 +66,30 @@ describe("Whitespace Issue Test", () => {
     // Should preserve both the explicit space and the leading space in span
     expect(content).toContain("Hello <element:span> World</element:span>");
   });
+
+  it("should preserve space before nested bold element like in HeroSubtitle", () => {
+    const path = getJSXElementPath(`
+      <p className="text-lg sm:text-xl text-gray-600 mb-10 max-w-xl mx-auto leading-relaxed">
+        Localize your React app in every language in minutes. Scale to millions
+        <b> from day one</b>.
+      </p>
+    `);
+
+    const content = extractJsxContent(path);
+    console.log("HeroSubtitle test content:", JSON.stringify(content));
+
+    // Let's also check the raw JSX structure
+    let jsxTexts: string[] = [];
+    path.traverse({
+      JSXText(textPath) {
+        jsxTexts.push(JSON.stringify(textPath.node.value));
+      },
+    });
+    console.log("HeroSubtitle JSXText nodes found:", jsxTexts);
+
+    // The bold element should have " from day one" with the leading space
+    expect(content).toContain("<element:b> from day one</element:b>");
+    // The full content should preserve the space between "millions" and the bold element
+    expect(content).toContain("millions <element:b> from day one</element:b>");
+  });
 });

--- a/packages/compiler/src/utils/jsx-content-whitespace.spec.ts
+++ b/packages/compiler/src/utils/jsx-content-whitespace.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { extractJsxContent } from "./jsx-content";
+import * as t from "@babel/types";
+import traverse, { NodePath } from "@babel/traverse";
+import { parse } from "@babel/parser";
+
+describe("Whitespace Issue Test", () => {
+  function parseJSX(code: string): t.File {
+    return parse(code, {
+      plugins: ["jsx"],
+      sourceType: "module",
+    });
+  }
+
+  function getJSXElementPath(code: string): NodePath<t.JSXElement> {
+    const ast = parseJSX(code);
+    let result: NodePath<t.JSXElement>;
+
+    traverse(ast, {
+      JSXElement(path) {
+        result = path;
+        path.stop();
+      },
+    });
+
+    return result!;
+  }
+
+  it("should preserve leading space in nested elements", () => {
+    const path = getJSXElementPath(`
+      <h1 className="text-5xl md:text-7xl font-bold text-white mb-6 leading-tight">
+        Hello World
+        <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-yellow-400 bg-clip-text text-transparent"> From Lingo.dev Compiler</span>
+      </h1>
+    `);
+    
+    const content = extractJsxContent(path);
+    console.log('Extracted content:', JSON.stringify(content));
+    
+    // Let's also check the raw JSX structure to understand what's happening
+    let jsxTexts: string[] = [];
+    path.traverse({
+      JSXText(textPath) {
+        jsxTexts.push(JSON.stringify(textPath.node.value));
+      }
+    });
+    console.log('JSXText nodes found:', jsxTexts);
+    
+    // The span should have " From Lingo.dev Compiler" with the leading space
+    expect(content).toContain("<element:span> From Lingo.dev Compiler</element:span>");
+  });
+
+  it("should handle explicit whitespace correctly", () => {
+    const path = getJSXElementPath(`
+      <div>
+        Hello{" "}
+        <span> World</span>
+      </div>
+    `);
+    
+    const content = extractJsxContent(path);
+    console.log('Explicit whitespace test:', JSON.stringify(content));
+    
+    // Should preserve both the explicit space and the leading space in span
+    expect(content).toContain("Hello <element:span> World</element:span>");
+  });
+});

--- a/packages/compiler/src/utils/jsx-content-whitespace.spec.ts
+++ b/packages/compiler/src/utils/jsx-content-whitespace.spec.ts
@@ -33,21 +33,23 @@ describe("Whitespace Issue Test", () => {
         <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-yellow-400 bg-clip-text text-transparent"> From Lingo.dev Compiler</span>
       </h1>
     `);
-    
+
     const content = extractJsxContent(path);
-    console.log('Extracted content:', JSON.stringify(content));
-    
+    console.log("Extracted content:", JSON.stringify(content));
+
     // Let's also check the raw JSX structure to understand what's happening
     let jsxTexts: string[] = [];
     path.traverse({
       JSXText(textPath) {
         jsxTexts.push(JSON.stringify(textPath.node.value));
-      }
+      },
     });
-    console.log('JSXText nodes found:', jsxTexts);
-    
+    console.log("JSXText nodes found:", jsxTexts);
+
     // The span should have " From Lingo.dev Compiler" with the leading space
-    expect(content).toContain("<element:span> From Lingo.dev Compiler</element:span>");
+    expect(content).toContain(
+      "<element:span> From Lingo.dev Compiler</element:span>",
+    );
   });
 
   it("should handle explicit whitespace correctly", () => {
@@ -57,10 +59,10 @@ describe("Whitespace Issue Test", () => {
         <span> World</span>
       </div>
     `);
-    
+
     const content = extractJsxContent(path);
-    console.log('Explicit whitespace test:', JSON.stringify(content));
-    
+    console.log("Explicit whitespace test:", JSON.stringify(content));
+
     // Should preserve both the explicit space and the leading space in span
     expect(content).toContain("Hello <element:span> World</element:span>");
   });

--- a/packages/compiler/src/utils/jsx-content.ts
+++ b/packages/compiler/src/utils/jsx-content.ts
@@ -127,41 +127,41 @@ function isWhitespace(nodePath: NodePath<t.JSXExpressionContainer>) {
 
 function normalizeJsxWhitespace(input: string) {
   // Handle single-line content
-  if (!input.includes('\n')) {
+  if (!input.includes("\n")) {
     // For single-line content, only trim if it appears to be formatting whitespace
     // (e.g., "   hello world   " should be trimmed to "hello world")
     // But preserve meaningful leading/trailing spaces (e.g., " hello" should stay " hello")
-    
+
     // If the content is mostly whitespace with some text, it's likely formatting
     const trimmed = input.trim();
-    if (trimmed.length === 0) return '';
-    
+    if (trimmed.length === 0) return "";
+
     // Check if we have excessive whitespace (more than 1 space on each side)
     const leadingMatch = input.match(/^\s*/);
     const trailingMatch = input.match(/\s*$/);
     const leadingSpaces = leadingMatch ? leadingMatch[0].length : 0;
     const trailingSpaces = trailingMatch ? trailingMatch[0].length : 0;
-    
+
     if (leadingSpaces > 1 || trailingSpaces > 1) {
       // This looks like formatting whitespace, collapse it
-      return input.replace(/\s+/g, ' ').trim();
+      return input.replace(/\s+/g, " ").trim();
     } else {
       // This looks like meaningful whitespace, preserve it but collapse internal spaces
-      return input.replace(/\s{2,}/g, ' ');
+      return input.replace(/\s{2,}/g, " ");
     }
   }
-  
+
   // Handle multi-line content
   const lines = input.split("\n");
   let result = "";
-  
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const trimmedLine = line.trim();
-    
+
     // Skip empty lines
     if (trimmedLine === "") continue;
-    
+
     // Check if this line contains a placeholder (explicit whitespace)
     if (trimmedLine.includes(WHITESPACE_PLACEHOLDER)) {
       // For lines with placeholders, preserve the original spacing
@@ -179,7 +179,7 @@ function normalizeJsxWhitespace(input: string) {
       result += trimmedLine;
     }
   }
-  
+
   // Collapse multiple spaces but preserve single spaces around placeholders
   result = result.replace(/\s{2,}/g, " ");
   return result.trim();

--- a/packages/compiler/src/utils/jsx-content.ts
+++ b/packages/compiler/src/utils/jsx-content.ts
@@ -167,15 +167,39 @@ function normalizeJsxWhitespace(input: string) {
       // For lines with placeholders, preserve the original spacing
       result += trimmedLine;
     } else if (
-      i > 0 &&
-      (trimmedLine.startsWith("<element:") ||
-        trimmedLine.startsWith("<function:") ||
-        trimmedLine.startsWith("{") ||
-        trimmedLine.startsWith("<expression/>"))
+      trimmedLine.startsWith("<element:") ||
+      trimmedLine.startsWith("<function:") ||
+      trimmedLine.startsWith("{") ||
+      trimmedLine.startsWith("<expression/>")
     ) {
+      // When we encounter an element/function/expression
+      // Add space only when:
+      // 1. We have existing content AND
+      // 2. Result doesn't already end with space or placeholder AND
+      // 3. The result ends with a word character (indicating text) AND
+      // 4. The element content starts with a space (indicating word continuation)
+      const shouldAddSpace =
+        result &&
+        !result.endsWith(" ") &&
+        !result.endsWith(WHITESPACE_PLACEHOLDER) &&
+        /\w$/.test(result) &&
+        // Check if element content starts with space by looking for "> " pattern
+        trimmedLine.includes("> ");
+
+      if (shouldAddSpace) {
+        result += " ";
+      }
       result += trimmedLine;
     } else {
-      if (result && !result.endsWith(" ")) result += " ";
+      // For regular text content, ensure proper spacing
+      // Only add space if the result doesn't already end with a space or placeholder
+      if (
+        result &&
+        !result.endsWith(" ") &&
+        !result.endsWith(WHITESPACE_PLACEHOLDER)
+      ) {
+        result += " ";
+      }
       result += trimmedLine;
     }
   }

--- a/packages/compiler/src/utils/jsx-content.ts
+++ b/packages/compiler/src/utils/jsx-content.ts
@@ -126,25 +126,61 @@ function isWhitespace(nodePath: NodePath<t.JSXExpressionContainer>) {
 }
 
 function normalizeJsxWhitespace(input: string) {
-  const lines = input.split("\n");
-  let result = "";
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
-    if (line === "") continue;
-    if (
-      i > 0 &&
-      (line.startsWith("<element:") ||
-        line.startsWith("<function:") ||
-        line.startsWith("{") ||
-        line.startsWith("<expression/>"))
-    ) {
-      result += line;
+  // Handle single-line content
+  if (!input.includes('\n')) {
+    // For single-line content, only trim if it appears to be formatting whitespace
+    // (e.g., "   hello world   " should be trimmed to "hello world")
+    // But preserve meaningful leading/trailing spaces (e.g., " hello" should stay " hello")
+    
+    // If the content is mostly whitespace with some text, it's likely formatting
+    const trimmed = input.trim();
+    if (trimmed.length === 0) return '';
+    
+    // Check if we have excessive whitespace (more than 1 space on each side)
+    const leadingMatch = input.match(/^\s*/);
+    const trailingMatch = input.match(/\s*$/);
+    const leadingSpaces = leadingMatch ? leadingMatch[0].length : 0;
+    const trailingSpaces = trailingMatch ? trailingMatch[0].length : 0;
+    
+    if (leadingSpaces > 1 || trailingSpaces > 1) {
+      // This looks like formatting whitespace, collapse it
+      return input.replace(/\s+/g, ' ').trim();
     } else {
-      if (result && !result.endsWith(" ")) result += " ";
-      result += line;
+      // This looks like meaningful whitespace, preserve it but collapse internal spaces
+      return input.replace(/\s{2,}/g, ' ');
     }
   }
-  // Collapse multiple spaces
-  result = result.replace(/\s+/g, " ");
+  
+  // Handle multi-line content
+  const lines = input.split("\n");
+  let result = "";
+  
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmedLine = line.trim();
+    
+    // Skip empty lines
+    if (trimmedLine === "") continue;
+    
+    // Check if this line contains a placeholder (explicit whitespace)
+    if (trimmedLine.includes(WHITESPACE_PLACEHOLDER)) {
+      // For lines with placeholders, preserve the original spacing
+      result += trimmedLine;
+    } else if (
+      i > 0 &&
+      (trimmedLine.startsWith("<element:") ||
+        trimmedLine.startsWith("<function:") ||
+        trimmedLine.startsWith("{") ||
+        trimmedLine.startsWith("<expression/>"))
+    ) {
+      result += trimmedLine;
+    } else {
+      if (result && !result.endsWith(" ")) result += " ";
+      result += trimmedLine;
+    }
+  }
+  
+  // Collapse multiple spaces but preserve single spaces around placeholders
+  result = result.replace(/\s{2,}/g, " ");
   return result.trim();
 }


### PR DESCRIPTION
fixes #984 
This pull request introduces improvements to whitespace normalization in JSX content handling within the Lingo.dev compiler. The key changes include refining the logic for preserving meaningful whitespace, adding targeted tests to ensure correctness, and cleaning up debug files. These updates enhance the robustness of JSX whitespace handling and improve code maintainability.

### Whitespace Normalization Enhancements:
* Improved the `normalizeJsxWhitespace` function to distinguish between formatting whitespace and meaningful leading/trailing spaces, ensuring proper preservation and collapsing of spaces as needed. Added handling for single-line and multi-line content separately. (`packages/compiler/src/utils/jsx-content.ts`, [packages/compiler/src/utils/jsx-content.tsR129-R184](diffhunk://#diff-c221deb69b53a09b21cfe5551de18cc0066b489bd26c7357e8005c3d9854e167R129-R184))

### Testing Additions:
* Added new tests in `jsx-content-whitespace.spec.ts` to verify the handling of leading spaces, explicit whitespace (`{" "}`), and nested JSX elements. These tests ensure the correctness of the updated `normalizeJsxWhitespace` logic. (`packages/compiler/src/utils/jsx-content-whitespace.spec.ts`, [packages/compiler/src/utils/jsx-content-whitespace.spec.tsR1-R67](diffhunk://#diff-f10d062be26cc2220ac9b518c885ca1e7afb591655c3dfb8b0a1e24ee8c4099eR1-R67))

### Documentation and Cleanup:
* Documented the changes in `.changeset/large-zoos-explain.md` and removed unnecessary debug/test files created during development. (`.changeset/large-zoos-explain.md`, [.changeset/large-zoos-explain.mdR1-R10](diffhunk://#diff-c5f46f64eb861f1527364228b4095753860bb876654999b06c88c5de1da4e5c0R1-R10))