### PR TITLE
feat: support comments in i18n.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -166,6 +166,7 @@
     "jsonrepair": "^3.11.2",
     "listr2": "^8.3.2",
     "lodash": "^4.17.21",
+    "jsonc-parser": "^3.3.1",
     "marked": "^15.0.6",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-gfm": "^3.1.0",

--- a/packages/cli/src/cli/utils/config.ts
+++ b/packages/cli/src/cli/utils/config.ts
@@ -2,6 +2,7 @@ import _ from "lodash";
 import fs from "fs";
 import path from "path";
 import { I18nConfig, parseI18nConfig } from "@lingo.dev/_spec";
+import { parse as parseJSONC } from "jsonc-parser";
 
 export function getConfig(resave = true): I18nConfig | null {
   const configFilePath = _getConfigFilePath();
@@ -12,7 +13,9 @@ export function getConfig(resave = true): I18nConfig | null {
   }
 
   const fileContents = fs.readFileSync(configFilePath, "utf8");
-  const rawConfig = JSON.parse(fileContents);
+  const rawConfig = parseJSONC(fileContents, undefined, {
+    allowTrailingComma: true,
+  }) as unknown;
 
   const result = parseI18nConfig(rawConfig);
   const didConfigChange = !_.isEqual(rawConfig, result);

--- a/packages/cli/src/cli/utils/config.ts
+++ b/packages/cli/src/cli/utils/config.ts
@@ -13,9 +13,7 @@ export function getConfig(resave = true): I18nConfig | null {
   }
 
   const fileContents = fs.readFileSync(configFilePath, "utf8");
-  const rawConfig = parseJSONC(fileContents, undefined, {
-    allowTrailingComma: true,
-  }) as unknown;
+  const rawConfig = parseJSONC(fileContents) as unknown;
 
   const result = parseI18nConfig(rawConfig);
   const didConfigChange = !_.isEqual(rawConfig, result);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,6 +385,9 @@ importers:
       json5:
         specifier: ^2.2.3
         version: 2.2.3
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       jsonrepair:
         specifier: ^3.11.2
         version: 3.11.2


### PR DESCRIPTION
The goal of this PR is to allow comments in the `i18n.json` file by parsing them as JSONC: https://jsonc.org/

This has a couple of benefits:

- if users have complex configurations, they can adequately comment them
- we can include comments in the code blocks that contain configuration (while still allowing users to copy/paste them)