### PR TITLE
feat: improve type-safety of CompilerParams

### DIFF
--- a/.changeset/fuzzy-mice-heal.md
+++ b/.changeset/fuzzy-mice-heal.md
@@ -1,0 +1,5 @@
+---
+"@lingo.dev/_compiler": minor
+---
+
+improve type safety of compiler params

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -44,6 +44,7 @@
     "@babel/traverse": "^7.27.4",
     "@babel/types": "^7.26.7",
     "@lingo.dev/_sdk": "workspace:*",
+    "@lingo.dev/_spec": "workspace:*",
     "@openrouter/ai-sdk-provider": "^0.7.1",
     "@prettier/sync": "^0.6.1",
     "ai": "^4.2.10",

--- a/packages/compiler/src/_base.ts
+++ b/packages/compiler/src/_base.ts
@@ -101,8 +101,11 @@ export type ModelMap = {
 /**
  * A pairing of a source and target locale.
  */
-export type SourceTargetLocale = LocalePair | AnyTargetLocale | AnySourceLocale | AnyLocale;
-
+export type SourceTargetLocale =
+  | LocalePair
+  | AnyTargetLocale
+  | AnySourceLocale
+  | AnyLocale;
 
 /**
  * A translation from a specific source locale to a specific target locale.

--- a/packages/compiler/src/_base.ts
+++ b/packages/compiler/src/_base.ts
@@ -101,7 +101,13 @@ export type ModelMap = {
 /**
  * A pairing of a source and target locale.
  */
-export type SourceTargetLocale = AnyTargetLocale | AnySourceLocale | AnyLocale;
+export type SourceTargetLocale = LocalePair | AnyTargetLocale | AnySourceLocale | AnyLocale;
+
+
+/**
+ * A translation from a specific source locale to a specific target locale.
+ */
+export type LocalePair = `${LocaleCode}:${LocaleCode}`;
 
 /**
  * A translation from a specific source locale to any target locale.

--- a/packages/compiler/src/_base.ts
+++ b/packages/compiler/src/_base.ts
@@ -1,6 +1,7 @@
 import generate, { GeneratorResult } from "@babel/generator";
 import * as t from "@babel/types";
 import * as parser from "@babel/parser";
+import { LocaleCode } from "@lingo.dev/_spec";
 
 /**
  * Options for configuring Lingo.dev Compiler.
@@ -16,7 +17,7 @@ export type CompilerParams = {
    *
    * @default "en"
    */
-  sourceLocale: string;
+  sourceLocale: LocaleCode;
   /**
    * The locale(s) to translate to.
    *
@@ -27,7 +28,7 @@ export type CompilerParams = {
    *
    * @default ["es"]
    */
-  targetLocales: string[];
+  targetLocales: LocaleCode[];
   /**
    * The name of the directory where translation files will be stored, relative to `sourceRoot`.
    *
@@ -78,7 +79,7 @@ export type CompilerParams = {
    *
    * @default {}
    */
-  models: "lingo.dev" | Record<string, string>;
+  models: "lingo.dev" | ModelMap;
   /**
    * Custom system prompt for the translation engine. If set, this prompt will override the default system prompt defined in Compiler.
    * Only works with custom models, not with Lingo.dev Engine.
@@ -89,6 +90,44 @@ export type CompilerParams = {
    */
   prompt?: string | null;
 };
+
+/**
+ * A mapping between locale pairings and the model to use for that pairing.
+ */
+export type ModelMap = {
+  [key in SourceTargetLocale]?: ModelIdentifier;
+};
+
+/**
+ * A pairing of source and target locale.
+ */
+export type SourceTargetLocale = AnyTargetLocale | AnySourceLocale | AnyLocale;
+
+/**
+ * A translation from a specific source locale to any target locale.
+ */
+export type AnyTargetLocale = `${LocaleCode}:${LocaleWildcard}`;
+
+/**
+ * A translation from any source locale to a specific target locale.
+ */
+export type AnySourceLocale = `${LocaleWildcard}:${LocaleCode}`;
+
+/**
+ * A translation from any source locale to any target locale.
+ */
+export type AnyLocale = `${LocaleWildcard}:${LocaleWildcard}`;
+
+/**
+ * A wildcard that matches any locale.
+ */
+export type LocaleWildcard = "*";
+
+/**
+ * The identifier of a model.
+ */
+export type ModelIdentifier = `${string}:${string}`;
+
 export type CompilerInput = {
   relativeFilePath: string;
   code: string;

--- a/packages/compiler/src/_base.ts
+++ b/packages/compiler/src/_base.ts
@@ -92,14 +92,14 @@ export type CompilerParams = {
 };
 
 /**
- * A mapping between locale pairings and the model to use for that pairing.
+ * A mapping between locale pairings and the model to use to translate that pairing.
  */
 export type ModelMap = {
   [key in SourceTargetLocale]?: ModelIdentifier;
 };
 
 /**
- * A pairing of source and target locale.
+ * A pairing of a source and target locale.
  */
 export type SourceTargetLocale = AnyTargetLocale | AnySourceLocale | AnyLocale;
 
@@ -119,12 +119,12 @@ export type AnySourceLocale = `${LocaleWildcard}:${LocaleCode}`;
 export type AnyLocale = `${LocaleWildcard}:${LocaleWildcard}`;
 
 /**
- * A wildcard that matches any locale.
+ * A wildcard symbol that matches any locale.
  */
 export type LocaleWildcard = "*";
 
 /**
- * The identifier of a model.
+ * The colon-separated identifier of a model to use for translation.
  */
 export type ModelIdentifier = `${string}:${string}`;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,6 +596,9 @@ importers:
       '@lingo.dev/_sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@lingo.dev/_spec':
+        specifier: workspace:*
+        version: link:../spec
       '@openrouter/ai-sdk-provider':
         specifier: ^0.7.1
         version: 0.7.1(ai@4.3.15(react@19.1.0)(zod@3.24.1))(zod@3.24.1)


### PR DESCRIPTION
This PR attempts to improve the type-safety of the `CompilerParams` type:

- set `sourceLocale` to `LocaleCode` instead of `string`
- set `targetLocale` to `LocaleCode` instead of `string`
- require the locale pairings in the `models` property to match one of the following formats:
  - `locale:locale`
  - `*:locale`
  - `locale:*`
  - `*:*`
- require the model identifier to be a colon separated string (e.g., `string:string`)

The model identifier can definitely be typed better — I'm imagining constructing a type of exact providers and models — but that's a bigger task.

## Example

![image](https://github.com/user-attachments/assets/ba138317-7258-411e-8896-f40699ee093d)
