### PR TITLE
fix(cli): make run cmd in CLI print a list of collected errors

### DIFF
--- a/.changeset/large-beds-cover.md
+++ b/.changeset/large-beds-cover.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+Make run cmd in CLI print a list of collected errors

--- a/packages/cli/src/cli/constants.ts
+++ b/packages/cli/src/cli/constants.ts
@@ -5,4 +5,5 @@ export const colors = {
   yellow: "#ffcc00",
   grey: "#808080",
   red: "#ff0000",
+  white: "#ffffff",
 };

--- a/packages/cli/src/cli/utils/ui.ts
+++ b/packages/cli/src/cli/utils/ui.ts
@@ -91,4 +91,15 @@ export async function renderSummary(results: Map<any, any>) {
     (r) => r.status === "error",
   ).length;
   console.log(`• ${chalk.hex(colors.yellow)(failedTasksCount)} failed`);
+
+  if (failedTasksCount > 0) {
+    console.log(chalk.hex(colors.orange)("\n[Failed]"));
+    for (const result of Array.from(results.values()).filter(
+      (r) => r.status === "error",
+    )) {
+      console.log(
+        `❌ ${chalk.hex(colors.white)(String(result.error.message))}\n`,
+      );
+    }
+  }
 }


### PR DESCRIPTION
fix : Make run cmd in CLI print a list of collected errors

Summary:
Should close https://github.com/lingodotdev/lingo.dev/issues/989

Added the changes in the ui.ts file as mentioned in the design notes in the issue to display the collected errors

Screenshot of the changes:
<img width="1204" height="425" alt="image" src="https://github.com/user-attachments/assets/d57df7bb-ebd2-4d91-98b6-be6a0e87b03d" />