### PR TITLE
feat: add typecheck scripts across monorepo packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "prepare": "husky",
     "build": "turbo build",
+    "typecheck": "turbo typecheck",
     "test": "turbo test",
     "new": "changeset",
     "new:empty": "changeset --empty",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -103,7 +103,7 @@
   "scripts": {
     "lingo.dev": "node --inspect=9229 ./bin/cli.mjs",
     "dev": "tsup --watch",
-    "build": "tsc --noEmit && tsup",
+    "build": "pnpm typecheck && tsup",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -104,6 +104,7 @@
     "lingo.dev": "node --inspect=9229 ./bin/cli.mjs",
     "dev": "tsup --watch",
     "build": "tsc --noEmit && tsup",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf build"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsc --noEmit && tsup",
+    "build": "pnpm typecheck && tsup",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf build",
     "test": "vitest --run",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsc --noEmit && tsup",
+    "typecheck": "tsc --noEmit",
     "clean": "rm -rf build",
     "test": "vitest --run",
     "test:watch": "vitest -w"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "dev": "unbuild && chokidar 'src/**/*' -c 'unbuild'",
     "build": "tsc --noEmit && unbuild",
+    "typecheck": "tsc --noEmit",
     "clean": "rm -rf build",
     "test": "vitest --run",
     "test:watch": "vitest -w"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "dev": "unbuild && chokidar 'src/**/*' -c 'unbuild'",
-    "build": "tsc --noEmit && unbuild",
+    "build": "pnpm typecheck && unbuild",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf build",
     "test": "vitest --run",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsc --noEmit && tsup",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "keywords": [],

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsc --noEmit && tsup",
+    "build": "pnpm typecheck && tsup",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsc --noEmit && tsup",
+    "build": "pnpm typecheck && tsup",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsc --noEmit && tsup",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
     "build": {
       "dependsOn": ["^build"]
     },
+    "typecheck": {},
     "test": {
       "dependsOn": ["^build"]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["typecheck", "^build"]
     },
     "typecheck": {},
     "test": {


### PR DESCRIPTION
## What

Add typecheck script to all packages and root-level turbo configuration to enable TypeScript type checking across the entire monorepo.

## Why?

Aside from being generally useful from a DX perspective, it'll make coding with AI a lot easier since it'll be able to typecheck more directly.

🤖 Generated with [Claude Code](https://claude.ai/code)