### PR TITLE
feat(cli): ignoredKeys in typescript being ignored

### DIFF
--- a/packages/cli/demo/typescript/es.ts
+++ b/packages/cli/demo/typescript/es.ts
@@ -1,9 +1,8 @@
 export default {
-  title: "Hola Mundo",
   description: "Esta es una descripción",
   field1: "Hola",
   field2: "Mundo",
   field3: {
-    field4: "Hola Mundo"
-  }
+    field4: "Hola Mundo",
+  },
 } as const;

--- a/packages/cli/demo/typescript/ru.ts
+++ b/packages/cli/demo/typescript/ru.ts
@@ -1,9 +1,8 @@
 export default {
-  title: "Привет, мир",
   description: "Это описание",
   field1: "Привет",
   field2: "Мир",
   field3: {
-    field4: "Привет, мир"
-  }
+    field4: "Привет, мир",
+  },
 } as const;

--- a/packages/cli/i18n.json
+++ b/packages/cli/i18n.json
@@ -37,7 +37,8 @@
       "include": ["demo/properties/[locale].properties"]
     },
     "typescript": {
-      "include": ["demo/typescript/[locale].ts"]
+      "include": ["demo/typescript/[locale].ts"],
+      "ignoredKeys": ["title"]
     },
     "xcode-strings": {
       "include": ["demo/xcode-strings/[locale].lproj/Localizable.strings"]

--- a/packages/cli/src/cli/cmd/run/_types.ts
+++ b/packages/cli/src/cli/cmd/run/_types.ts
@@ -28,6 +28,7 @@ export type CmdRunTask = {
   injectLocale: string[];
   lockedKeys: string[];
   lockedPatterns: string[];
+  ignoredKeys: string[];
   onlyKeys: string[];
 };
 

--- a/packages/cli/src/cli/cmd/run/execute.ts
+++ b/packages/cli/src/cli/cmd/run/execute.ts
@@ -127,6 +127,7 @@ function createLoaderForTask(assignedTask: CmdRunTask) {
     },
     assignedTask.lockedKeys,
     assignedTask.lockedPatterns,
+    assignedTask.ignoredKeys,
   );
   bucketLoader.setDefaultLocale(assignedTask.sourceLocale);
 

--- a/packages/cli/src/cli/cmd/run/plan.ts
+++ b/packages/cli/src/cli/cmd/run/plan.ts
@@ -132,6 +132,7 @@ export default async function plan(
                   injectLocale: bucket.injectLocale || [],
                   lockedKeys: bucket.lockedKeys || [],
                   lockedPatterns: bucket.lockedPatterns || [],
+                  ignoredKeys: bucket.ignoredKeys || [],
                   onlyKeys: input.flags.key || [],
                 });
               }

--- a/packages/cli/src/cli/loaders/ensure-key-order.ts
+++ b/packages/cli/src/cli/loaders/ensure-key-order.ts
@@ -10,11 +10,14 @@ export default function createEnsureKeyOrderLoader(): ILoader<
     pull: async (_locale, input) => {
       return input;
     },
-    push: async (_locale, data, originalInput) => {
+    push: async (locale, data, originalInput) => {
       if (!originalInput || !data) {
         return data;
       }
-      return reorderKeys(data, originalInput);
+
+      const result = reorderKeys(data, originalInput);
+
+      return result;
     },
   });
 }

--- a/packages/cli/src/cli/loaders/flat.ts
+++ b/packages/cli/src/cli/loaders/flat.ts
@@ -55,6 +55,7 @@ function createNormalizeLoader(): ILoader<
           return decodeURIComponent(String(key));
         },
       });
+
       return { denormalized, keysMap: keysMap || {} };
     },
   });

--- a/packages/cli/src/cli/loaders/ignored-keys.ts
+++ b/packages/cli/src/cli/loaders/ignored-keys.ts
@@ -8,17 +8,21 @@ export default function createIgnoredKeysLoader(
 ): ILoader<Record<string, any>, Record<string, any>> {
   return createLoader({
     pull: async (locale, data) => {
-      const result = _.omitBy(data, (value, key) =>
+      // Keep all keys that are NOT ignored
+      const filteredData = _.omitBy(data, (value, key) =>
         _isIgnoredKey(key, ignoredKeys),
       );
-      return result;
+
+      return filteredData;
     },
-    push: async (locale, data, originalInput, originalLocale, pullInput) => {
-      const ignoredSubObject = _.pickBy(pullInput, (value, key) =>
+
+    push: async (locale, data) => {
+      // Remove ignored keys from the data being pushed to target files
+      const filteredData = _.omitBy(data, (value, key) =>
         _isIgnoredKey(key, ignoredKeys),
       );
-      const result = _.merge({}, data, ignoredSubObject);
-      return result;
+
+      return filteredData;
     },
   });
 }

--- a/packages/cli/src/cli/loaders/index.ts
+++ b/packages/cli/src/cli/loaders/index.ts
@@ -276,10 +276,10 @@ export default function createBucketLoader(
         createTypescriptLoader(),
         createFlatLoader(),
         createEnsureKeyOrderLoader(),
-        createSyncLoader(),
         createLockedKeysLoader(lockedKeys || []),
+        createSyncLoader(),
         createIgnoredKeysLoader(ignoredKeys || []),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(options.returnUnlocalizedKeys, ignoredKeys),
       );
     case "txt":
       return composeLoaders(

--- a/packages/cli/src/cli/loaders/locked-keys.ts
+++ b/packages/cli/src/cli/loaders/locked-keys.ts
@@ -15,7 +15,9 @@ export default function createLockedKeysLoader(
         .pickBy((value, key) => _isLockedKey(key, lockedKeys))
         .value();
 
-      return _.merge({}, data, lockedSubObject);
+      const result = _.merge({}, data, lockedSubObject);
+
+      return result;
     },
   });
 }

--- a/packages/cli/src/cli/loaders/sync.ts
+++ b/packages/cli/src/cli/loaders/sync.ts
@@ -22,9 +22,12 @@ export default function createSyncLoader(): ILoader<
         return data;
       }
 
-      return _.chain(originalInput || {})
-        .mapValues((value, key) => data[key])
-        .value();
+      // Only include keys that exist in the original input to maintain sync
+      const syncedData = _.chain(data)
+        .pickBy((value, key) => originalInput.hasOwnProperty(key))
+        .value() as Record<string, string>;
+
+      return syncedData;
     },
   });
 }


### PR DESCRIPTION
fixes #1050 
## ignoredKeys TS Support

Adds working TypeScript support for `ignoredKeys`.

## Usage

Works with:
```typescript
export default {
  info: { /* ... */ },
  error: { /* ... */ },
};

export const message = {
  info: { /* ... */ },
  error: { /* ... */ },
};
```

Now, `ignoredKeys` properly ignores keys for both export styles.