### PR TITLE
feat(cli): added ignorekeys support for multiple buckets

### DIFF
--- a/packages/cli/src/cli/cmd/run/_types.ts
+++ b/packages/cli/src/cli/cmd/run/_types.ts
@@ -28,7 +28,6 @@ export type CmdRunTask = {
   injectLocale: string[];
   lockedKeys: string[];
   lockedPatterns: string[];
-  ignoredKeys: string[];
   onlyKeys: string[];
 };
 

--- a/packages/cli/src/cli/cmd/run/execute.ts
+++ b/packages/cli/src/cli/cmd/run/execute.ts
@@ -127,7 +127,6 @@ function createLoaderForTask(assignedTask: CmdRunTask) {
     },
     assignedTask.lockedKeys,
     assignedTask.lockedPatterns,
-    assignedTask.ignoredKeys,
   );
   bucketLoader.setDefaultLocale(assignedTask.sourceLocale);
 

--- a/packages/cli/src/cli/cmd/run/plan.ts
+++ b/packages/cli/src/cli/cmd/run/plan.ts
@@ -132,7 +132,6 @@ export default async function plan(
                   injectLocale: bucket.injectLocale || [],
                   lockedKeys: bucket.lockedKeys || [],
                   lockedPatterns: bucket.lockedPatterns || [],
-                  ignoredKeys: bucket.ignoredKeys || [],
                   onlyKeys: input.flags.key || [],
                 });
               }


### PR DESCRIPTION
Depends on #1065 
## This PR adds support for ignored keys (ignoreKeys) to multiple bucket types in the lingo.dev project. The following bucket types now support ignored keys:

json
yaml
php
vue-json
flutter
xml
android
csv
po
xcode-stringsdict
xcode-xcstrings
xliff
typescript
