### PR TITLE
feat: add locale-codes export to CLI package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,6 +63,11 @@
       "types": "./build/react/react-router.d.ts",
       "import": "./build/react/react-router.mjs",
       "require": "./build/react/react-router.cjs"
+    },
+    "./locale-codes": {
+      "types": "./build/locale-codes.d.ts",
+      "import": "./build/locale-codes.mjs",
+      "require": "./build/locale-codes.cjs"
     }
   },
   "typesVersions": {
@@ -90,6 +95,9 @@
       ],
       "react/react-router": [
         "./build/react/react-router.d.ts"
+      ],
+      "locale-codes": [
+        "./build/locale-codes.d.ts"
       ]
     }
   },
@@ -127,6 +135,7 @@
     "@inkjs/ui": "^2.0.0",
     "@inquirer/prompts": "^7.8.0",
     "@lingo.dev/_compiler": "workspace:*",
+    "@lingo.dev/_locales": "workspace:*",
     "@lingo.dev/_react": "workspace:*",
     "@lingo.dev/_sdk": "workspace:*",
     "@lingo.dev/_spec": "workspace:*",

--- a/packages/cli/src/locale-codes/index.ts
+++ b/packages/cli/src/locale-codes/index.ts
@@ -1,0 +1,3 @@
+// Re-export everything but with type checking
+export type * from "@lingo.dev/_locales";
+export * from "@lingo.dev/_locales";

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "react/rsc": "src/react/rsc.ts",
     "react/react-router": "src/react/react-router.ts",
     compiler: "src/compiler/index.ts",
+    "locale-codes": "src/locale-codes/index.ts",
   },
   outDir: "build",
   format: ["cjs", "esm"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,9 @@ importers:
       '@lingo.dev/_compiler':
         specifier: workspace:*
         version: link:../compiler
+      '@lingo.dev/_locales':
+        specifier: workspace:*
+        version: link:../locales
       '@lingo.dev/_react':
         specifier: workspace:*
         version: link:../react


### PR DESCRIPTION
## Summary
- Adds `lingo.dev/locale-codes` export to make the locale parsing and validation utilities available to users
- Follows the existing re-export pattern used by other packages (sdk, spec, compiler, react)

## Changes
- Added `@lingo.dev/_locales` as a workspace dependency to the CLI package
- Created `src/locale-codes/index.ts` re-export file following the symmetric pattern
- Updated `package.json` with locale-codes export configuration
- Updated `tsup.config.ts` to build the locale-codes entry point

## Usage
Users can now import locale utilities directly:
```typescript
import { parseLocale, isValidLocale, getCountryName } from "lingo.dev/locale-codes";
```

## Test Plan
- [x] Built the package successfully with `pnpm build`
- [x] Verified exports are working correctly
- [x] Confirmed structure is symmetric with other re-exports

Closes P-283