### PR TITLE
fix: biome JS API v3 bug

### DIFF
--- a/.changeset/brown-vans-bow.md
+++ b/.changeset/brown-vans-bow.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+fix Biome JS API v3 bug


### PR DESCRIPTION
The bug is specifically in how the JS API v3 handles configuration serialization/deserialization when certain properties like $schema, vcs, and files are present. 

Applied workaround filters out those properties - we're avoiding the buggy code path in the JS API while the CLI never encounters this issue in the first place.

(The Biome CLI doesn't have this issue because it uses a completely different, more direct code path written in Rust.) 