### PR TITLE
docs: add guide for Next.js

### DIFF
--- a/docs/nextjs-app-router.md
+++ b/docs/nextjs-app-router.md
@@ -27,15 +27,7 @@ Follow the official Next.js App Router internationalization guide.
 // next.config.ts
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  experimental: {
-    i18nRouting: true, // Enable App Router–style locale handling
-  },
-  i18n: {
-    locales: ["en", "es", "fr"],
-    defaultLocale: "en",
-  },
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;
 ```


### PR DESCRIPTION
Fixes #1334 

Description

This PR adds a complete integration guide showing how to set up Lingo.dev CLI with Next.js (App Router) using react-intl.
The guide walks through a clean setup of i18n support, configuring Lingo.dev synchronization, and rendering localized strings inside a Next.js app.

Files Added

docs/nextjs-app-routes.md — New integration tutorial for Next.js App Router

Testing Notes

Followed all steps on a fresh Next.js 15 project using create-next-app@latest

Verified language switching and translations with react-intl

Tested Lingo.dev CLI commands: lingo.dev pull, lingo.dev push, and lingo.dev fix

Some Screenshots of the guide 
<img width="1281" height="619" alt="Screenshot 2025-10-30 091830" src="https://github.com/user-attachments/assets/a8ff2352-08d1-4d7e-b0c7-b58a8aa0e1cf" />
<img width="1274" height="667" alt="2" src="https://github.com/user-attachments/assets/839d2558-25a5-4a20-bf64-c762466e2ebe" />
<img width="1268" height="667" alt="3" src="https://github.com/user-attachments/assets/7b7a76c2-06a3-4fe8-8ac2-ddc7ef231d68" />
