### PR TITLE
chore(ci): add matrix workflow to build demo apps [skip i18n]

### DIFF
--- a/.github/workflows/build-demos.yml
+++ b/.github/workflows/build-demos.yml
@@ -1,0 +1,70 @@
+name: Build Demo Apps
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-demos:
+    name: Build demo/${{ matrix.app }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [next-app, vite-project, adonisjs, react-router-app]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.12.2
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        id: pnpm-install
+        with:
+          version: 9.12.3
+          run_install: false
+
+      - name: Configure pnpm cache
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Restore pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Turbo telemetry
+        run: pnpm turbo telemetry disable
+
+      - name: Configure Turbo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+
+      - name: Build demo app
+        env:
+          CI: true
+        run: |
+          mkdir -p logs
+          pnpm turbo build --force --filter ./demo/${{ matrix.app }} 2>&1 | tee logs/build-${{ matrix.app }}.log
+
+      - name: Upload build logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs-${{ matrix.app }}
+          path: logs/build-${{ matrix.app }}.log
+          if-no-files-found: ignore


### PR DESCRIPTION
chore(ci): add matrix workflow to build demo apps [skip i18n]

This PR introduces a GitHub Actions workflow that builds each demo app in isolation using a matrix:
- demo/next-app
- demo/vite-project
- demo/adonisjs
- demo/react-router-app

Key improvements:
- Consistent Node (20.12.2) and pnpm (9.12.3) setup
- pnpm store and Turbo cache for faster CI runs
- Turbo filtered builds per demo to catch regressions early
- Build logs uploaded as artifacts on failure for easier debugging

Context and rationale: Fixes #1355