### PR TITLE
feat(i18n): added odia language support

### DIFF
--- a/i18n.json
+++ b/i18n.json
@@ -19,7 +19,8 @@
       "bn",
       "fa",
       "pl",
-      "tr"
+      "tr",
+      "or"
     ]
   },
   "buckets": {


### PR DESCRIPTION
### Summary
Added Odia ('or') to the i18n.json locale targets for localization support.

### Changes
- Updated **i18n.json** to include 'or' (Odia) under locale targets.

### Motivation
To expand translation coverage and include Odia speakers.

### Checklist
- [x] Verified JSON structure and syntax
- [x] Followed commitlint convention
- [x] Tested build without errors
