### PR TITLE
feat(utils): add GH_TOKEN and .env fallback support for getGitHubToken

### DIFF
--- a/scripts/docs/src/utils.ts
+++ b/scripts/docs/src/utils.ts
@@ -20,11 +20,25 @@ export function getRepoRoot(): string {
   throw new Error("Could not find project root");
 }
 
-export function getGitHubToken() {
-  const token = process.env.GITHUB_TOKEN;
+export function getGitHubToken(): string {
+  let token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 
   if (!token) {
-    throw new Error("GITHUB_TOKEN environment variable is required.");
+    const envPath = path.join(process.cwd(), ".env");
+    if (existsSync(envPath)) {
+      const content = readFileSync(envPath, "utf-8");
+      const match = content.match(/^GITHUB_TOKEN\s*=\s*(.+)$/m);
+      if (match) token = match[1].trim();
+    }
+  }
+
+  if (!token) {
+    throw new Error(
+      `Missing GitHub authentication token.
+Please set one of the following:
+- GITHUB_TOKEN or GH_TOKEN environment variable
+- Or add GITHUB_TOKEN to a .env file in the project root`
+    );
   }
 
   return token;


### PR DESCRIPTION
Added fallback logic in getGitHubToken() to improve reliability:

Supports GH_TOKEN as an alternative when GITHUB_TOKEN is not set.

Reads .env file for GITHUB_TOKEN if both environment variables are missing.

Provides more informative error messages for missing authentication tokens.

This change improves developer experience when running locally or in CI environments without a preset GITHUB_TOKEN.