### PR TITLE
fix(cli): correct doc link keys and update android loader references

### DIFF
--- a/packages/cli/src/cli/loaders/android.ts
+++ b/packages/cli/src/cli/loaders/android.ts
@@ -137,7 +137,7 @@ export default function createAndroidLoader(): ILoader<
         console.error("Error parsing Android resource file:", error);
         throw new CLIError({
           message: "Failed to parse Android resource file",
-          docUrl: "androidResouceError",
+          docUrl: "androidResourceError",
         });
       }
     },
@@ -174,7 +174,7 @@ export default function createAndroidLoader(): ILoader<
         console.error("Error generating Android resource file:", error);
         throw new CLIError({
           message: "Failed to generate Android resource file",
-          docUrl: "androidResouceError",
+          docUrl: "androidResourceError",
         });
       }
     },
@@ -758,7 +758,7 @@ function asString(value: any, name: string): string {
   }
   throw new CLIError({
     message: `Expected string value for resource "${name}"`,
-    docUrl: "androidResouceError",
+    docUrl: "androidResourceError",
   });
 }
 
@@ -768,7 +768,7 @@ function asStringArray(value: any, name: string): string[] {
   }
   throw new CLIError({
     message: `Expected array of strings for resource "${name}"`,
-    docUrl: "androidResouceError",
+    docUrl: "androidResourceError",
   });
 }
 
@@ -779,7 +779,7 @@ function asPluralMap(value: any, name: string): Record<string, string> {
       if (typeof pluralValue !== "string") {
         throw new CLIError({
           message: `Expected plural item "${quantity}" of "${name}" to be a string`,
-          docUrl: "androidResouceError",
+          docUrl: "androidResourceError",
         });
       }
       result[quantity] = pluralValue;
@@ -788,7 +788,7 @@ function asPluralMap(value: any, name: string): Record<string, string> {
   }
   throw new CLIError({
     message: `Expected object value for plurals resource "${name}"`,
-    docUrl: "androidResouceError",
+    docUrl: "androidResourceError",
   });
 }
 
@@ -803,7 +803,7 @@ function asBoolean(value: any, name: string): boolean {
   }
   throw new CLIError({
     message: `Expected boolean value for resource "${name}"`,
-    docUrl: "androidResouceError",
+    docUrl: "androidResourceError",
   });
 }
 
@@ -813,7 +813,7 @@ function asInteger(value: any, name: string): number {
   }
   throw new CLIError({
     message: `Expected number value for resource "${name}"`,
-    docUrl: "androidResouceError",
+    docUrl: "androidResourceError",
   });
 }
 
@@ -1161,7 +1161,7 @@ function inferTypeFromValue(value: any): AndroidResourceType {
   }
   throw new CLIError({
     message: "Unable to infer Android resource type from payload",
-    docUrl: "androidResouceError",
+    docUrl: "androidResourceError",
   });
 }
 

--- a/packages/cli/src/cli/utils/errors.ts
+++ b/packages/cli/src/cli/utils/errors.ts
@@ -3,6 +3,9 @@ export const docLinks = {
   bucketNotFound: "https://lingo.dev/cli",
   authError: "https://lingo.dev/cli",
   localeTargetNotFound: "https://lingo.dev/cli",
+  // corrected key (previously misspelled as "lockFiletNotFound")
+  lockFileNotFound: "https://lingo.dev/cli",
+  // legacy alias for backward compatibility
   lockFiletNotFound: "https://lingo.dev/cli",
   failedReplexicaEngine: "https://lingo.dev/cli",
   placeHolderFailed: "https://lingo.dev/cli",
@@ -10,6 +13,9 @@ export const docLinks = {
   connectionFailed: "https://lingo.dev/cli",
   invalidType: "https://lingo.dev/cli",
   invalidPathPattern: "https://lingo.dev/cli",
+  // corrected key (previously misspelled as "androidResouceError")
+  androidResourceError: "https://lingo.dev/cli",
+  // legacy alias for backward compatibility
   androidResouceError: "https://lingo.dev/cli",
   invalidBucketType: "https://lingo.dev/cli",
   invalidStringDict: "https://lingo.dev/cli",


### PR DESCRIPTION
Fixes typos in CLI doc link keys and updates references in android loader

What I changed
- Added corrected keys to `packages/cli/src/cli/utils/errors.ts`: `lockFileNotFound` and `androidResourceError`.
- Kept legacy misspelled aliases (`lockFiletNotFound`, `androidResouceError`) for backward compatibility.
- Replaced usages of `androidResouceError` with `androidResourceError` in `packages/cli/src/cli/loaders/android.ts`.
- (Temporary) added and then stashed a unit test for doc link keys — not included in this PR. If you prefer the test included, I can add it in a follow-up.

Why
- Fixes confusing typos in doc link keys and improves consistency. Keeping aliases prevents breaking older references.

How to test locally
1. From repo root:
```powershell
pnpm install
pnpm --filter @lingo.dev/cli test