### PR TITLE
Fixes #1511

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -17,6 +17,7 @@ pnpm install
 pnpm build
 ```
 
+
 Lingo.dev uses [pnpm](https://pnpm.io/) as its package manager.
 
 ### 2. Link the CLI Package

--- a/demo/next-app/README.md
+++ b/demo/next-app/README.md
@@ -2,4 +2,4 @@
 
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app) and [Lingo.dev Compiler](https://lingo.dev/compiler) implementation.
 
-Documentation: https://lingo.dev/compiler/frameworks/nextjs
+Documentation: https://lingo.dev/en/compiler/frameworks/nextjs-app-router

--- a/scripts/docs/src/generate-cli-docs.ts
+++ b/scripts/docs/src/generate-cli-docs.ts
@@ -18,7 +18,6 @@ import { unified } from "unified";
 import { pathToFileURL } from "url";
 import { createOrUpdateGitHubComment, getRepoRoot } from "./utils";
 import { format as prettierFormat, resolveConfig } from "prettier";
-
 type CommandWithInternals = Command & {
   _hidden?: boolean;
   _helpCommand?: Command;


### PR DESCRIPTION
Replaced outdated /en/compiler/frameworks/nextjs links with the correct /en/compiler/frameworks/nextjs-app-router path in code files to resolve 404 errors and ensure correct documentation redirection.