### PR TITLE
feat: enable trackpad swipe navigation for back/forward gestures

### DIFF
--- a/demo/adonisjs/inertia/css/app.css
+++ b/demo/adonisjs/inertia/css/app.css
@@ -8,3 +8,9 @@ body {
   height: 100%;
   width: 100%;
 }
+
+html,
+body {
+  touch-action: pan-y;
+  overscroll-behavior-x: auto;
+}

--- a/demo/next-app/src/app/globals.css
+++ b/demo/next-app/src/app/globals.css
@@ -18,3 +18,9 @@
     --foreground: #ededed;
   }
 }
+
+html,
+body {
+  touch-action: pan-y;
+  overscroll-behavior-x: auto;
+}

--- a/demo/react-router-app/app/app.css
+++ b/demo/react-router-app/app/app.css
@@ -13,3 +13,9 @@ body {
     color-scheme: dark;
   }
 }
+
+html,
+body {
+  touch-action: pan-y;
+  overscroll-behavior-x: auto;
+}

--- a/demo/vite-project/src/index.css
+++ b/demo/vite-project/src/index.css
@@ -66,3 +66,9 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+html,
+body {
+  touch-action: pan-y;
+  overscroll-behavior-x: auto;
+}


### PR DESCRIPTION
Fixes #1268

- Add touch-action: pan-y and overscroll-behavior-x: auto to demo global CSS
- Enables native two-finger horizontal swipe on macOS for browser navigation
- Tested on Next.js, Vite, React Router, and AdonisJS demos