### PR TITLE
feat: streamline contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,5 +73,6 @@ pnpm changeset status --since origin/main
 
 - Automated code review by AI bots provides suggestions
 - Human reviewers make final decisions
+- **Address maintainer comments promptly** - PRs with unaddressed comments will be closed to keep the repo clean. Feel free to recreate once issues are resolved.
 
 Questions? Join our [Discord](https://lingo.dev/go/discord)!


### PR DESCRIPTION
Closes #1495

## Summary
- Reduced guide from ~187 lines to ~73 lines
- Removed verbose explanations and redundant content
- Moved LLM provider guide to separate doc (out of scope for general contribution guide)
- Made requirements crystal clear with critical warning upfront
- Kept only tactical, actionable information

## Changes
- Added critical requirements warning
- Streamlined workflow steps
- Consolidated PR requirements
- Simplified local development section
- Removed duplicate/unnecessary content