### PR TITLE
fix: update deprecated gemini model references to 2.5 #1601

### DIFF
--- a/packages/compiler/src/_base.ts
+++ b/packages/compiler/src/_base.ts
@@ -71,7 +71,7 @@ export type CompilerParams = {
    * If set to an object, the compiler will use the model(s) specified in the object:
    *
    * - The key is a string that represents the source and target locales, separated by a colon (e.g., `"en:es"`).
-   * - The value is a string that represents the LLM provider and model, separated by a colon (e.g., `"google:gemini-2.0-flash"`).
+   * - The value is a string that represents the LLM provider and model, separated by a colon (e.g., `"google:gemini-2.5-flash"`).
    *
    * You can use `*` as a wildcard to match any locale.
    *

--- a/packages/compiler/src/lib/lcp/api/index.ts
+++ b/packages/compiler/src/lib/lcp/api/index.ts
@@ -289,7 +289,7 @@ export class LCPAPI {
    * Instantiates an AI model based on provider and model ID.
    * Includes CI/CD API key checks.
    * @param providerId The ID of the AI provider (e.g., "groq", "google").
-   * @param modelId The ID of the specific model (e.g., "llama3-8b-8192", "gemini-2.0-flash").
+   * @param modelId The ID of the specific model (e.g., "llama3-8b-8192", "gemini-2.5-flash").
    * @param targetLocale The target locale being translated to (for logging/error messages).
    * @returns An instantiated AI LanguageModel.
    * @throws Error if the provider is not supported or API key is missing in CI/CD.


### PR DESCRIPTION
## Summary

[Updates documentation references and JSDoc comments to replace deprecated Gemini 1.5 and 2.0 model examples with the current stable Gemini 2.5 series.]

## Changes

- [packages/compiler/src/_base.ts: Updated the models parameter example to use gemini-2.5-flash instead of the deprecated version.]
- [packages/compiler/src/lib/lcp/api/index.ts: Updated the @param modelId documentation in _createAiModel to reference gemini-2.5-flash.]

## Testing

**Business logic tests added:**

- [ ] [This is a documentation/comment update only and does not modify application logic]
- [ ] []
- [ ] All tests pass locally

## Visuals

**Required for UI/UX changes:**

- [ ] Documentation update only
- [ ] Video demo for interactions (< 30s)

## Checklist

- [ ] Changeset added (if version bump needed)
- [ ] Tests cover business logic (not just happy path)
- [ ] No breaking changes (or documented below)

Closes #[1601]
