### PR TITLE
fix(cli): resolve race condition in locale processing

### DIFF
--- a/.changeset/all-candies-reply.md
+++ b/.changeset/all-candies-reply.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+fix racing condition where concurrent processing could use data from the wrong locale

--- a/packages/cli/src/cli/loaders/_utils.ts
+++ b/packages/cli/src/cli/loaders/_utils.ts
@@ -48,8 +48,10 @@ export function createLoader<I, O, C>(
   const state = {
     defaultLocale: undefined as string | undefined,
     originalInput: undefined as I | undefined | null,
-    pullInput: undefined as I | undefined | null,
-    pullOutput: undefined as O | undefined | null,
+    // Store pullInput and pullOutput per-locale to avoid race conditions
+    // when multiple locales are processed concurrently
+    pullInputByLocale: new Map<string, I | null>(),
+    pullOutputByLocale: new Map<string, O | null>(),
     initCtx: undefined as C | undefined,
   };
   return {
@@ -81,7 +83,7 @@ export function createLoader<I, O, C>(
         state.originalInput = input || null;
       }
 
-      state.pullInput = input;
+      state.pullInputByLocale.set(locale, input || null);
       const result = await lDefinition.pull(
         locale,
         input,
@@ -89,7 +91,7 @@ export function createLoader<I, O, C>(
         state.defaultLocale,
         state.originalInput!,
       );
-      state.pullOutput = result;
+      state.pullOutputByLocale.set(locale, result);
 
       return result;
     },
@@ -101,13 +103,25 @@ export function createLoader<I, O, C>(
         throw new Error("Cannot push data without pulling first");
       }
 
+      // Use locale-specific pullInput/pullOutput if available,
+      // otherwise fall back to the default locale's values for backward compatibility
+      // (some loaders push for locales that were never explicitly pulled)
+      const pullInput =
+        state.pullInputByLocale.get(locale) ??
+        state.pullInputByLocale.get(state.defaultLocale) ??
+        null;
+      const pullOutput =
+        state.pullOutputByLocale.get(locale) ??
+        state.pullOutputByLocale.get(state.defaultLocale) ??
+        null;
+
       const pushResult = await lDefinition.push(
         locale,
         data,
         state.originalInput,
         state.defaultLocale,
-        state.pullInput!,
-        state.pullOutput!,
+        pullInput!,
+        pullOutput!,
       );
       return pushResult;
     },


### PR DESCRIPTION
## Summary

@vrcprl #1662 didn't fully fix #1661 because there's a race condition in `_utils.ts` where `pullInput` and `pullOutput` are stored as single values that get overwritten on each `pull()` call

## Changes

- Changed state storage from single values to per-locale using `Map`

## Testing

**Business logic tests added:**

- [x] Check the Language header is correct on concurrent processing
- [x] All tests pass locally

I also made sure to test locally with `npm link` this time. Sorry I didn't do it last time.

## Visuals

**Required for UI/UX changes:**

- [ ] Before/after screenshots attached
- [ ] Video demo for interactions (< 30s)

## Checklist

- [x] Changeset added (if version bump needed)
- [ ] Tests cover business logic (not just happy path)
- [x] No breaking changes (or documented below)

Closes #1661 
