### PR TITLE
feat(cli): add deprecation warning to 'i18n' command

### DIFF
--- a/.changeset/wild-cameras-wash.md
+++ b/.changeset/wild-cameras-wash.md
@@ -1,2 +1,5 @@
 ---
+"lingo.dev": patch
 ---
+
+Add deprecation warning to 'i18n' command, directing users to use 'run' instead

--- a/packages/cli/src/cli/cmd/i18n.ts
+++ b/packages/cli/src/cli/cmd/i18n.ts
@@ -94,6 +94,16 @@ export default new Command()
     updateGitignore();
 
     const ora = Ora();
+
+    // Show deprecation warning
+    console.log();
+    ora.warn(
+      chalk.yellow(
+        " DEPRECATED: 'i18n' is deprecated. Please use 'run' instead. Docs: https://lingo.dev/cli/commands/run",
+      ),
+    );
+    console.log();
+
     let flags: ReturnType<typeof parseFlags>;
 
     try {


### PR DESCRIPTION
## Summary

Adds a deprecation warning when running the `i18n` command to encourage users to switch to `run`.

## Changes

- Added a deprecation notice using `ora.warn` and `chalk.yellow` for visibility.
- Included a direct link to the `run` command documentation.
- Added vertical spacing (`console.log`) before and after the warning for better readability in the CLI.

## Testing

**Testing performed:**

- [x] Run `i18n` command and verify the warning appears.
- [x] Verify that the documentation link is correct and clickable.

## Visuals

- [X] Screenshot of the terminal output attached below

## Checklist

- [x] Changeset added (if version bump needed)
- [ ] Tests cover business logic (not just happy path)
- [x] No breaking changes (or documented below)

Closes N/A