### PR TITLE
feat(cli): exclude previous translations from reference when --force flag is used

### DIFF
--- a/.changeset/fair-cows-pay.md
+++ b/.changeset/fair-cows-pay.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+Exclude previous translations from LLM reference when --force flag is used. The localization engine now receives an empty object instead of existing translations, ensuring truly fresh translations are generated without influence from previous versions.

--- a/packages/cli/src/cli/cmd/i18n.ts
+++ b/packages/cli/src/cli/cmd/i18n.ts
@@ -446,7 +446,8 @@ export default new Command()
                     sourceData,
                     processableData,
                     targetLocale,
-                    targetData,
+                    // When --force is used, exclude previous translations from reference to ensure fresh translations
+                    targetData: flags.force ? {} : targetData,
                   },
                   (progress, sourceChunk, processedChunk) => {
                     bucketOra.text = `[${sourceLocale} -> ${targetLocale}] [${

--- a/packages/cli/src/cli/cmd/run/execute.ts
+++ b/packages/cli/src/cli/cmd/run/execute.ts
@@ -254,7 +254,8 @@ function createWorkerTask(args: {
                 sourceLocale: assignedTask.sourceLocale,
                 targetLocale: assignedTask.targetLocale,
                 sourceData,
-                targetData,
+                // When --force is used, exclude previous translations from reference to ensure fresh translations
+                targetData: args.ctx.flags.force ? {} : targetData,
                 processableData,
                 hints: relevantHints,
               },


### PR DESCRIPTION
## Summary                                                                                                                
                                                                                                                            
Exclude previous translations from reference when `--force` flag is used, ensuring fresh translations are generated without influence from previous versions.                                                                       
                                                                                                                            
## Changes                                                                                                                
                                                                                                                            
- Modified `i18n.ts` to pass empty object instead of existing translations when `--force` flag is active                  
- Updated `execute.ts` worker task to apply same logic for consistent behavior across execution paths                                                                      
                                                                                                                            
## Testing                                                                                                                
                                                                                                                            
**Testing performed:**                                                                                           
                                                                                                                            
- [x] Test `--force` flag excludes previous translations from reference data                                              
- [x] Test normal mode (without `--force`) includes previous translations as reference                                    
- [x] Verify translations are generated fresh when `--force` is used                                                                                                                                                 
                                                                                                                       
## Checklist  
                                                                                                            
- [x] Changeset added (if version bump needed)                                                                            
- [ ] Tests cover business logic (not just happy path)                                                                    
- [ ] No breaking changes (or documented below)                                                                           
                                                                                                                     
Closes N/A             