### PR TITLE
feat(community): add lingo-todo-app demo with Lingo.dev integration

### DIFF
--- a/community/lingo-todo-app/README.md
+++ b/community/lingo-todo-app/README.md
@@ -1,0 +1,79 @@
+# Lingo.dev Todo App - Multilingual Demo
+
+A simple, beautiful todo app that's **fully multilingual** thanks to Lingo.dev compiler!
+
+## 🌍 Features
+
+- ✅ Add, complete, and delete todos
+- 🌐 Automatic multilingual support (5 languages)
+- ⚡ Language switching in real-time
+- 💅 Modern dark theme UI
+- 📱 Fully responsive design
+
+## 🎯 Supported Languages
+
+- 🇺🇸 English
+- 🇪🇸 Spanish (Español)
+- 🇫🇷 French (Français)
+- 🇩🇪 German (Deutsch)
+- 🇯🇵 Japanese (日本語)
+
+## 🚀 How to Run
+
+1. **Install dependencies:**
+
+   ```bash
+   cd community/lingo-todo-app
+   pnpm install
+   ```
+
+2. **Start development server:**
+
+   ```bash
+   pnpm dev
+   ```
+
+3. **Open in browser:**
+   Navigate to http://localhost:3000
+
+4. **Switch languages:**
+   Click the language switcher in the header to see everything translate instantly!
+
+## 🔧 How Lingo.dev Works Here
+
+This app demonstrates **zero-code translations**:
+
+- Write your app in English
+- Lingo.dev compiler automatically translates everything
+- Switch languages with `<LocaleSwitcher />` component
+- **No translation files, no translation keys, no manual translations!**
+
+The magic is in the `vite.config.ts`:
+
+```typescript
+lingoCompilerPlugin({
+  sourceLocale: "en",
+  targetLocales: ["es", "fr", "de", "ja"],
+  models: "lingo.dev",
+  dev: { usePseudotranslator: true },
+});
+```
+
+## 📦 Technologies
+
+- React 19
+- TypeScript
+- Vite
+- Lingo.dev Compiler
+- Lucide Icons
+- CSS3
+
+## 🎓 Learn More
+
+- [Lingo.dev Documentation](https://lingo.dev)
+- [Compiler Guide](https://lingo.dev/compiler)
+- [Discord Community](https://lingo.dev/go/discord)
+
+---
+
+**Made for the Lingo.dev Community Swag Campaign** 🎉

--- a/community/lingo-todo-app/index.html
+++ b/community/lingo-todo-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Todo App - Multilingual with Lingo.dev</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/community/lingo-todo-app/package.json
+++ b/community/lingo-todo-app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "lingo-todo-app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 3000",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lingo": "lingo"
+  },
+  "dependencies": {
+    "@lingo.dev/compiler": "^0.1.9",
+    "lucide-react": "^0.545.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^5.0.4",
+    "typescript": "^5.7.2",
+    "vite": "^7.3.0"
+  }
+}

--- a/community/lingo-todo-app/src/.lingo/translation-server.log
+++ b/community/lingo-todo-app/src/.lingo/translation-server.log
@@ -1,0 +1,284 @@
+2026-01-22T14:01:20.234Z [INFO] [Lingo.dev] 🔧 Initializing translator...
+2026-01-22T14:01:20.250Z [DEBUG] [Lingo.dev] Starting translation server on port 60000
+2026-01-22T14:01:20.311Z [INFO] [Lingo.dev] Translation server listening on http://127.0.0.1:60000
+2026-01-22T14:01:20.353Z [INFO] [Lingo.dev] WebSocket server initialized
+2026-01-22T14:01:23.703Z [DEBUG] [Lingo.dev] WebSocket client connected. Total clients: 1
+2026-01-22T14:01:23.894Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/es
+2026-01-22T14:01:23.897Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/es
+2026-01-22T14:01:23.903Z [DEBUG] [Lingo.dev] OPTIONS /translations/es
+2026-01-22T14:01:23.908Z [INFO] [Lingo.dev] 📥 Received: POST /translations/es
+2026-01-22T14:01:23.911Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/es
+2026-01-22T14:01:23.913Z [DEBUG] [Lingo.dev] POST /translations/es
+2026-01-22T14:01:23.916Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:01:23.918Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:01:23.921Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:01:23.924Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:01:23.926Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to es
+2026-01-22T14:01:23.928Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:01:23.931Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:01:24.515Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:01:29.055Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/ja
+2026-01-22T14:01:29.060Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/ja
+2026-01-22T14:01:29.067Z [DEBUG] [Lingo.dev] OPTIONS /translations/ja
+2026-01-22T14:01:29.073Z [INFO] [Lingo.dev] 📥 Received: POST /translations/ja
+2026-01-22T14:01:29.076Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/ja
+2026-01-22T14:01:29.080Z [DEBUG] [Lingo.dev] POST /translations/ja
+2026-01-22T14:01:29.086Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:01:29.089Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:01:29.095Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:01:29.098Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:01:29.101Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to ja
+2026-01-22T14:01:29.105Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:01:29.108Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:01:29.686Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:01:31.869Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/en
+2026-01-22T14:01:31.875Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/en
+2026-01-22T14:01:31.883Z [DEBUG] [Lingo.dev] OPTIONS /translations/en
+2026-01-22T14:01:31.890Z [INFO] [Lingo.dev] 📥 Received: POST /translations/en
+2026-01-22T14:01:31.893Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/en
+2026-01-22T14:01:31.897Z [DEBUG] [Lingo.dev] POST /translations/en
+2026-01-22T14:01:31.900Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:01:31.902Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:01:31.907Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:01:31.910Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:01:31.913Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to en
+2026-01-22T14:01:31.918Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:01:31.921Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:01:32.386Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:01:34.271Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/es
+2026-01-22T14:01:34.280Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/es
+2026-01-22T14:01:34.288Z [DEBUG] [Lingo.dev] OPTIONS /translations/es
+2026-01-22T14:01:34.292Z [INFO] [Lingo.dev] 📥 Received: POST /translations/es
+2026-01-22T14:01:34.296Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/es
+2026-01-22T14:01:34.303Z [DEBUG] [Lingo.dev] POST /translations/es
+2026-01-22T14:01:34.307Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:01:34.311Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:01:34.315Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:01:34.319Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:01:34.323Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to es
+2026-01-22T14:01:34.328Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:01:34.333Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:01:34.799Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:02:26.827Z [DEBUG] [Lingo.dev] WebSocket client disconnected. Total clients: 0
+2026-01-22T14:02:28.211Z [DEBUG] [Lingo.dev] WebSocket client connected. Total clients: 1
+2026-01-22T14:02:28.418Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/es
+2026-01-22T14:02:28.421Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/es
+2026-01-22T14:02:28.427Z [DEBUG] [Lingo.dev] OPTIONS /translations/es
+2026-01-22T14:02:28.430Z [INFO] [Lingo.dev] 📥 Received: POST /translations/es
+2026-01-22T14:02:28.433Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/es
+2026-01-22T14:02:28.436Z [DEBUG] [Lingo.dev] POST /translations/es
+2026-01-22T14:02:28.441Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:02:28.444Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:02:28.447Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:02:28.450Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:02:28.453Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to es
+2026-01-22T14:02:28.456Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:02:28.458Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:02:28.942Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:03:14.814Z [INFO] [Lingo.dev] 🔧 Initializing translator...
+2026-01-22T14:03:14.830Z [DEBUG] [Lingo.dev] Starting translation server on port 60000
+2026-01-22T14:03:14.859Z [INFO] [Lingo.dev] Translation server listening on http://127.0.0.1:60000
+2026-01-22T14:03:14.893Z [INFO] [Lingo.dev] WebSocket server initialized
+2026-01-22T14:03:17.146Z [DEBUG] [Lingo.dev] WebSocket client connected. Total clients: 1
+2026-01-22T14:03:17.353Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/es
+2026-01-22T14:03:17.357Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/es
+2026-01-22T14:03:17.362Z [DEBUG] [Lingo.dev] OPTIONS /translations/es
+2026-01-22T14:03:17.366Z [INFO] [Lingo.dev] 📥 Received: POST /translations/es
+2026-01-22T14:03:17.370Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/es
+2026-01-22T14:03:17.372Z [DEBUG] [Lingo.dev] POST /translations/es
+2026-01-22T14:03:17.374Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:03:17.376Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:03:17.379Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:03:17.382Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:03:17.385Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to es
+2026-01-22T14:03:17.388Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:03:17.391Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:03:17.988Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:03:19.465Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/en
+2026-01-22T14:03:19.471Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/en
+2026-01-22T14:03:19.479Z [DEBUG] [Lingo.dev] OPTIONS /translations/en
+2026-01-22T14:03:19.486Z [INFO] [Lingo.dev] 📥 Received: POST /translations/en
+2026-01-22T14:03:19.491Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/en
+2026-01-22T14:03:19.494Z [DEBUG] [Lingo.dev] POST /translations/en
+2026-01-22T14:03:19.497Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:03:19.501Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:03:19.505Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:03:19.510Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:03:19.513Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to en
+2026-01-22T14:03:19.517Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:03:19.520Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:03:19.987Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:03:22.191Z [INFO] [Lingo.dev] 📥 Received: POST /translations/es
+2026-01-22T14:03:22.204Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/es
+2026-01-22T14:03:22.221Z [DEBUG] [Lingo.dev] POST /translations/es
+2026-01-22T14:03:22.227Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:03:22.236Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:03:22.240Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:03:22.243Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:03:22.247Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to es
+2026-01-22T14:03:22.251Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:03:22.255Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:03:22.704Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:03:25.335Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/fr
+2026-01-22T14:03:25.340Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/fr
+2026-01-22T14:03:25.348Z [DEBUG] [Lingo.dev] OPTIONS /translations/fr
+2026-01-22T14:03:25.354Z [INFO] [Lingo.dev] 📥 Received: POST /translations/fr
+2026-01-22T14:03:25.359Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/fr
+2026-01-22T14:03:25.362Z [DEBUG] [Lingo.dev] POST /translations/fr
+2026-01-22T14:03:25.368Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:03:25.372Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:03:25.375Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:03:25.380Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:03:25.386Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to fr
+2026-01-22T14:03:25.390Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:03:25.395Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:03:25.998Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:03:27.914Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/de
+2026-01-22T14:03:27.921Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/de
+2026-01-22T14:03:27.929Z [DEBUG] [Lingo.dev] OPTIONS /translations/de
+2026-01-22T14:03:27.940Z [INFO] [Lingo.dev] 📥 Received: POST /translations/de
+2026-01-22T14:03:27.944Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/de
+2026-01-22T14:03:27.948Z [DEBUG] [Lingo.dev] POST /translations/de
+2026-01-22T14:03:27.953Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:03:27.958Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:03:27.962Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:03:27.967Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:03:27.970Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to de
+2026-01-22T14:03:27.974Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:03:27.977Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:03:28.583Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:05:13.541Z [INFO] [Lingo.dev] 🔧 Initializing translator...
+2026-01-22T14:05:13.555Z [DEBUG] [Lingo.dev] Starting translation server on port 60000
+2026-01-22T14:05:13.583Z [INFO] [Lingo.dev] Translation server listening on http://127.0.0.1:60000
+2026-01-22T14:05:13.620Z [INFO] [Lingo.dev] WebSocket server initialized
+2026-01-22T14:05:27.007Z [DEBUG] [Lingo.dev] WebSocket client connected. Total clients: 1
+2026-01-22T14:05:27.219Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/en
+2026-01-22T14:05:27.222Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/en
+2026-01-22T14:05:27.226Z [DEBUG] [Lingo.dev] OPTIONS /translations/en
+2026-01-22T14:05:27.233Z [INFO] [Lingo.dev] 📥 Received: POST /translations/en
+2026-01-22T14:05:27.236Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/en
+2026-01-22T14:05:27.238Z [DEBUG] [Lingo.dev] POST /translations/en
+2026-01-22T14:05:27.242Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:05:27.246Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:05:27.249Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:05:27.251Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:05:27.255Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to en
+2026-01-22T14:05:27.258Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:05:27.260Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:05:27.732Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:06:05.710Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/es
+2026-01-22T14:06:05.719Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/es
+2026-01-22T14:06:05.726Z [DEBUG] [Lingo.dev] OPTIONS /translations/es
+2026-01-22T14:06:05.737Z [INFO] [Lingo.dev] 📥 Received: POST /translations/es
+2026-01-22T14:06:05.746Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/es
+2026-01-22T14:06:05.750Z [DEBUG] [Lingo.dev] POST /translations/es
+2026-01-22T14:06:05.754Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:06:05.757Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:06:05.760Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:06:05.765Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:06:05.769Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to es
+2026-01-22T14:06:05.772Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:06:05.774Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:06:06.374Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:06:08.495Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/fr
+2026-01-22T14:06:08.501Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/fr
+2026-01-22T14:06:08.508Z [DEBUG] [Lingo.dev] OPTIONS /translations/fr
+2026-01-22T14:06:08.512Z [INFO] [Lingo.dev] 📥 Received: POST /translations/fr
+2026-01-22T14:06:08.516Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/fr
+2026-01-22T14:06:08.520Z [DEBUG] [Lingo.dev] POST /translations/fr
+2026-01-22T14:06:08.523Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:06:08.526Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:06:08.531Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:06:08.533Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:06:08.537Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to fr
+2026-01-22T14:06:08.540Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:06:08.543Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:06:09.130Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:06:11.936Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/de
+2026-01-22T14:06:11.941Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/de
+2026-01-22T14:06:11.948Z [DEBUG] [Lingo.dev] OPTIONS /translations/de
+2026-01-22T14:06:11.952Z [INFO] [Lingo.dev] 📥 Received: POST /translations/de
+2026-01-22T14:06:11.956Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/de
+2026-01-22T14:06:11.958Z [DEBUG] [Lingo.dev] POST /translations/de
+2026-01-22T14:06:11.962Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:06:11.966Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:06:11.970Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:06:11.974Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:06:11.977Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to de
+2026-01-22T14:06:11.981Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:06:11.984Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:06:12.603Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:06:14.840Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/ja
+2026-01-22T14:06:14.847Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/ja
+2026-01-22T14:06:14.852Z [DEBUG] [Lingo.dev] OPTIONS /translations/ja
+2026-01-22T14:06:14.855Z [INFO] [Lingo.dev] 📥 Received: POST /translations/ja
+2026-01-22T14:06:14.859Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/ja
+2026-01-22T14:06:14.862Z [DEBUG] [Lingo.dev] POST /translations/ja
+2026-01-22T14:06:14.866Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:06:14.868Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:06:14.872Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:06:14.877Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:06:14.881Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to ja
+2026-01-22T14:06:14.884Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:06:14.888Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:06:15.429Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:06:17.606Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/en
+2026-01-22T14:06:17.612Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/en
+2026-01-22T14:06:17.620Z [DEBUG] [Lingo.dev] OPTIONS /translations/en
+2026-01-22T14:06:17.629Z [INFO] [Lingo.dev] 📥 Received: POST /translations/en
+2026-01-22T14:06:17.634Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/en
+2026-01-22T14:06:17.638Z [DEBUG] [Lingo.dev] POST /translations/en
+2026-01-22T14:06:17.642Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:06:17.646Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:06:17.650Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:06:17.654Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:06:17.658Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to en
+2026-01-22T14:06:17.661Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:06:17.664Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:06:18.126Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:06:27.394Z [DEBUG] [Lingo.dev] WebSocket client disconnected. Total clients: 0
+2026-01-22T14:06:28.676Z [DEBUG] [Lingo.dev] WebSocket client connected. Total clients: 1
+2026-01-22T14:06:28.874Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/en
+2026-01-22T14:06:28.878Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/en
+2026-01-22T14:06:28.882Z [DEBUG] [Lingo.dev] OPTIONS /translations/en
+2026-01-22T14:06:28.887Z [INFO] [Lingo.dev] 📥 Received: POST /translations/en
+2026-01-22T14:06:28.890Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/en
+2026-01-22T14:06:28.893Z [DEBUG] [Lingo.dev] POST /translations/en
+2026-01-22T14:06:28.895Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:06:28.899Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:06:28.902Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:06:28.905Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:06:28.908Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to en
+2026-01-22T14:06:28.911Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:06:28.914Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:06:29.394Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:06:39.412Z [DEBUG] [Lingo.dev] WebSocket client disconnected. Total clients: 0
+2026-01-22T14:06:40.678Z [DEBUG] [Lingo.dev] WebSocket client connected. Total clients: 1
+2026-01-22T14:06:40.880Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/en
+2026-01-22T14:06:40.883Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/en
+2026-01-22T14:06:40.887Z [DEBUG] [Lingo.dev] OPTIONS /translations/en
+2026-01-22T14:06:40.892Z [INFO] [Lingo.dev] 📥 Received: POST /translations/en
+2026-01-22T14:06:40.896Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/en
+2026-01-22T14:06:40.899Z [DEBUG] [Lingo.dev] POST /translations/en
+2026-01-22T14:06:40.902Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:06:40.904Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:06:40.907Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:06:40.909Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:06:40.913Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to en
+2026-01-22T14:06:40.915Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:06:40.917Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:06:41.391Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle
+2026-01-22T14:06:59.112Z [INFO] [Lingo.dev] 📥 Received: OPTIONS /translations/de
+2026-01-22T14:06:59.119Z [INFO] [Lingo.dev] 🔄 Processing: OPTIONS /translations/de
+2026-01-22T14:06:59.125Z [DEBUG] [Lingo.dev] OPTIONS /translations/de
+2026-01-22T14:06:59.132Z [INFO] [Lingo.dev] 📥 Received: POST /translations/de
+2026-01-22T14:06:59.137Z [INFO] [Lingo.dev] 🔄 Processing: POST /translations/de
+2026-01-22T14:06:59.141Z [DEBUG] [Lingo.dev] POST /translations/de
+2026-01-22T14:06:59.144Z [DEBUG] [Lingo.dev] Reading request body...
+2026-01-22T14:06:59.148Z [DEBUG] [Lingo.dev] Chunk read, body: {"hashes":["275f790196cf","fee014c637fc","b9e5b4bf3c2f","8159488c01f3","1746220339f6","58e3db13993f","2deb7b37dfcf","b311000b03a9","7d85a85fcb31"]}
+2026-01-22T14:06:59.152Z [DEBUG] [Lingo.dev] Parsed hashes: 275f790196cf,fee014c637fc,b9e5b4bf3c2f,8159488c01f3,1746220339f6,58e3db13993f,2deb7b37dfcf,b311000b03a9,7d85a85fcb31
+2026-01-22T14:06:59.157Z [DEBUG] [Lingo.dev] Reloaded metadata: 9 entries
+2026-01-22T14:06:59.161Z [INFO] [Lingo.dev] 🔄 Translating 9 hashes to de
+2026-01-22T14:06:59.165Z [DEBUG] [Lingo.dev] 🔄 Hashes: 275f790196cf, fee014c637fc, b9e5b4bf3c2f, 8159488c01f3, 1746220339f6, 58e3db13993f, 2deb7b37dfcf, b311000b03a9, 7d85a85fcb31
+2026-01-22T14:06:59.170Z [DEBUG] [Lingo.dev] [BUSY] Server is now busy (1 active)
+2026-01-22T14:06:59.636Z [DEBUG] [Lingo.dev] [IDLE] Server is now idle

--- a/community/lingo-todo-app/src/App.tsx
+++ b/community/lingo-todo-app/src/App.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { LocaleSwitcher } from "@lingo.dev/compiler/react";
+import { CheckCircle2, Circle, Trash2, Plus, Globe } from "lucide-react";
+
+interface Todo {
+  id: number;
+  text: string;
+  completed: boolean;
+}
+
+export default function App() {
+  const [todos, setTodos] = useState<Todo[]>([
+    { id: 1, text: "Learn Lingo.dev", completed: false },
+    { id: 2, text: "Build multilingual app", completed: false },
+    { id: 3, text: "Deploy to production", completed: false },
+  ]);
+  const [input, setInput] = useState("");
+
+  const addTodo = () => {
+    if (input.trim()) {
+      setTodos([...todos, { id: Date.now(), text: input, completed: false }]);
+      setInput("");
+    }
+  };
+
+  const toggleTodo = (id: number) => {
+    setTodos(
+      todos.map((t) => (t.id === id ? { ...t, completed: !t.completed } : t)),
+    );
+  };
+
+  const deleteTodo = (id: number) => {
+    setTodos(todos.filter((t) => t.id !== id));
+  };
+
+  const completedCount = todos.filter((t) => t.completed).length;
+
+  return (
+    <div className="app">
+      <header className="header">
+        <div className="header-content">
+          <h1>My Todo List</h1>
+          <div className="header-right">
+            <LocaleSwitcher
+              locales={[
+                { code: "en", label: "English" },
+                { code: "es", label: "Español" },
+                { code: "fr", label: "Français" },
+                { code: "de", label: "Deutsch" },
+                { code: "ja", label: "日本語" },
+              ]}
+              className="locale-switcher"
+            />
+            <div className="badge">
+              <Globe size={16} />
+              <span>Powered by Lingo.dev</span>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="main">
+        <div className="container">
+          <div className="input-section">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyPress={(e) => e.key === "Enter" && addTodo()}
+              placeholder="Add a new task..."
+              className="input"
+            />
+            <button onClick={addTodo} className="add-btn">
+              <Plus size={20} />
+              Add Task
+            </button>
+          </div>
+
+          <div className="stats">
+            <span>Total: {todos.length} tasks</span>
+            <span>Completed: {completedCount}</span>
+            <span>Remaining: {todos.length - completedCount}</span>
+          </div>
+
+          <div className="todo-list">
+            {todos.length === 0 ? (
+              <div className="empty">
+                <p>No tasks yet. Add one to get started!</p>
+              </div>
+            ) : (
+              todos.map((todo) => (
+                <div
+                  key={todo.id}
+                  className={`todo-item ${todo.completed ? "completed" : ""}`}
+                >
+                  <button
+                    onClick={() => toggleTodo(todo.id)}
+                    className="checkbox-btn"
+                  >
+                    {todo.completed ? (
+                      <CheckCircle2 size={24} className="checked" />
+                    ) : (
+                      <Circle size={24} />
+                    )}
+                  </button>
+                  <span className="todo-text">{todo.text}</span>
+                  <button
+                    onClick={() => deleteTodo(todo.id)}
+                    className="delete-btn"
+                  >
+                    <Trash2 size={18} />
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div className="footer">
+            <p>
+              This app is fully multilingual! Switch languages to see everything
+              translate automatically.
+            </p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/community/lingo-todo-app/src/index.css
+++ b/community/lingo-todo-app/src/index.css
@@ -1,0 +1,275 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --primary: #3b82f6;
+  --primary-dark: #2563eb;
+  --success: #10b981;
+  --danger: #ef4444;
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface-hover: #334155;
+  --text: #f1f5f9;
+  --text-muted: #94a3b8;
+  --border: #334155;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 1.5rem 2rem;
+  sticky: top;
+}
+
+.header-content {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header h1 {
+  font-size: 1.875rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--success) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.locale-switcher {
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.locale-switcher:hover {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+
+.badge {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  border-radius: 8px;
+  color: var(--primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.main {
+  flex: 1;
+  padding: 2rem;
+}
+
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.input-section {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.input {
+  flex: 1;
+  background: var(--surface);
+  border: 2px solid var(--border);
+  color: var(--text);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-size: 1rem;
+  transition: all 0.2s;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.input::placeholder {
+  color: var(--text-muted);
+}
+
+.add-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--primary);
+  border: none;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.add-btn:hover {
+  background: var(--primary-dark);
+  transform: translateY(-2px);
+}
+
+.stats {
+  display: flex;
+  justify-content: space-around;
+  padding: 1rem;
+  background: var(--surface);
+  border-radius: 12px;
+  margin-bottom: 2rem;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+.stats span {
+  font-weight: 600;
+}
+
+.todo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.todo-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  background: var(--surface);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  transition: all 0.2s;
+}
+
+.todo-item:hover {
+  background: var(--surface-hover);
+}
+
+.todo-item.completed {
+  opacity: 0.6;
+}
+
+.checkbox-btn {
+  background: none;
+  border: none;
+  color: var(--primary);
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s;
+}
+
+.checkbox-btn:hover {
+  transform: scale(1.1);
+}
+
+.checkbox-btn .checked {
+  color: var(--success);
+}
+
+.todo-text {
+  flex: 1;
+  font-size: 1rem;
+  word-break: break-word;
+}
+
+.todo-item.completed .todo-text {
+  text-decoration: line-through;
+  color: var(--text-muted);
+}
+
+.delete-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.delete-btn:hover {
+  color: var(--danger);
+  transform: scale(1.2);
+}
+
+.empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-muted);
+}
+
+.empty p {
+  font-size: 1.125rem;
+}
+
+.footer {
+  text-align: center;
+  padding: 1rem;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  border-top: 1px solid var(--border);
+  margin-top: 2rem;
+}
+
+@media (max-width: 640px) {
+  .header-content {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .input-section {
+    flex-direction: column;
+  }
+
+  .add-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .stats {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}

--- a/community/lingo-todo-app/src/main.tsx
+++ b/community/lingo-todo-app/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { LingoProvider } from "@lingo.dev/compiler/react";
+import App from "./App";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <LingoProvider>
+      <App />
+    </LingoProvider>
+  </StrictMode>,
+);

--- a/community/lingo-todo-app/tsconfig.json
+++ b/community/lingo-todo-app/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/community/lingo-todo-app/vite.config.ts
+++ b/community/lingo-todo-app/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { lingoCompilerPlugin } from "@lingo.dev/compiler/vite";
+
+export default defineConfig({
+  plugins: [
+    lingoCompilerPlugin({
+      sourceRoot: "src",
+      lingoDir: ".lingo",
+      sourceLocale: "en",
+      targetLocales: ["es", "fr", "de", "ja"],
+      useDirective: false,
+      models: "lingo.dev",
+      buildMode: "translate",
+      dev: {
+        usePseudotranslator: true,
+      },
+    }),
+    react(),
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,40 @@ importers:
         specifier: 2.6.1
         version: 2.6.1
 
+  community/lingo-todo-app:
+    dependencies:
+      '@lingo.dev/compiler':
+        specifier: ^0.1.9
+        version: 0.1.9(@types/node@22.13.5)(@types/react@19.2.7)(encoding@0.1.13)(next@16.1.1(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.1.12)
+      lucide-react:
+        specifier: ^0.545.0
+        version: 0.545.0(react@19.2.3)
+      react:
+        specifier: ^19.2.0
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.13.5
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^5.0.4
+        version: 5.0.4(vite@7.3.0(@types/node@22.13.5)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.0
+        version: 7.3.0(@types/node@22.13.5)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
   demo/new-compiler-next16:
     dependencies:
       '@lingo.dev/compiler':
@@ -236,7 +270,7 @@ importers:
         version: 39.34.3
       '@inkjs/ui':
         specifier: 2.0.0
-        version: 2.0.0(ink@4.2.0(@types/react@19.2.7)(react@19.2.3))
+        version: 2.0.0(ink@4.2.0(react@19.2.3))
       '@inquirer/prompts':
         specifier: 7.8.0
         version: 7.8.0(@types/node@22.10.2)
@@ -359,7 +393,7 @@ importers:
         version: 3.0.0
       ink-spinner:
         specifier: 5.0.0
-        version: 5.0.0(ink@4.2.0(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+        version: 5.0.0(ink@4.2.0(react@19.2.3))(react@19.2.3)
       inquirer:
         specifier: 12.6.0
         version: 12.6.0(@types/node@22.10.2)
@@ -2515,19 +2549,46 @@ packages:
   '@lingo.dev/_compiler@0.8.8':
     resolution: {integrity: sha512-gSqUFF6VxFAJCyjTJvCDqDIu+RBfmLEcRL1M8Z3tTtH9AHIXTTXUV+6t2udQJ1dTsytXPdFbpdNXknoMHMJvkQ==}
 
+  '@lingo.dev/_compiler@0.9.0':
+    resolution: {integrity: sha512-fidghgHhhaX64OMFaRdLF/mze88+h9l1n9tW5ILaIoSVN6lOHTBA4nBMVQJJBCeIOWrHrFFMoW/np+tYqX27BA==}
+
   '@lingo.dev/_locales@0.3.1':
     resolution: {integrity: sha512-9iTwe+14un1WnS/Ao2Mea5tmEV2IXSo41fJoV+FLOc4ZGfVcoGy4LgLf6QAUdYMuIpyitGu0qkPmUvAqoWoH9Q==}
+
+  '@lingo.dev/_locales@0.3.3':
+    resolution: {integrity: sha512-50blm6NdDEM9P/GtWmyrfuxILe+9s3g+wMmETQafV97Geh/OQeW8Ej/8XcozZBHNRLIrCsUn53RS+x5kczAM0Q==}
 
   '@lingo.dev/_react@0.7.5':
     resolution: {integrity: sha512-c6HkkgVdlUBkRBo4Atj4L9xGB4l2YdSejD14Uls0nb3S2KTLhD3OwnSHpeZHdOneO3+JDxqSJ7i0emJLiPXIvQ==}
     peerDependencies:
       next: 15.3.8
 
+  '@lingo.dev/_react@0.7.6':
+    resolution: {integrity: sha512-D7pk63tj4aOBBB0xOvM7KBo+mb0MobYQLNwkECeiRkxhjMKhjj4ANwb3Uj90XB4tjY1InW9V4Ho1jpYG5yZsnA==}
+    peerDependencies:
+      next: 15.3.8
+
   '@lingo.dev/_sdk@0.13.4':
     resolution: {integrity: sha512-K3Sk0cvnpV5AtaYlpimeAAweCxahOJGWIuNrTJyE7NQer3Nbb3keCUy8DfVlpthAX8dOe+A1UBAWJokuaf568A==}
 
+  '@lingo.dev/_sdk@0.13.7':
+    resolution: {integrity: sha512-qn+1I0wj5ZePC7VR2TIw+SZTrFF/aVpEg1gfF9IXRYueDgmtMyi9YGDQPpMkXhx7daFYH3YCSPYkkRDu6MEvLw==}
+
   '@lingo.dev/_spec@0.44.4':
     resolution: {integrity: sha512-SJifegtTD+VF0WUZtZVQytCX/YdOSLqCt9WTc0EXIx2t8arPnIgE2+rmPCJ84GYQhFc5BaTbYEo2pQhKQCOMNg==}
+
+  '@lingo.dev/_spec@0.46.0':
+    resolution: {integrity: sha512-XlZ7bdW10C51hpJnQObnI3GuCwssqWt0yksATB+RilxUpyyZMpAxm4MU/zdZUzgiLGXohmtn7UVROauQaFe9OA==}
+
+  '@lingo.dev/compiler@0.1.9':
+    resolution: {integrity: sha512-YV9GWRnLA3CWGkvKrNwOxHu8s3sgxmIJnQwQjF3VM3RTKW/1CIF5x4BonCWXe2pY5NBPhYvbEv6+fXSg6mm0iQ==}
+    peerDependencies:
+      next: ^15.0.0 || ^16.0.4
+      react: ^19.0.0
+      react-dom: ' ^19.0.0'
+    peerDependenciesMeta:
+      next:
+        optional: true
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -6940,6 +7001,11 @@ packages:
 
   lingo.dev@0.117.21:
     resolution: {integrity: sha512-vN60EkTlQArtN6keqdxJkjtAR2V1Ce+fnP+hBQcFBM6AgY49d+KBf1cJP2q8phHS8Cxo9jH20HTj6kUjIr9HFw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  lingo.dev@0.122.1:
+    resolution: {integrity: sha512-ZtEARIHyFyTsvzaSjimfq6GIVOTaWU+5dTMafLa4KnQI49YCVT3fslHe51GVIlkyZGRKdsBi1dxJ6qphohoxAQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -11602,7 +11668,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inkjs/ui@2.0.0(ink@4.2.0(@types/react@19.2.7)(react@19.2.3))':
+  '@inkjs/ui@2.0.0(ink@4.2.0(react@19.2.3))':
     dependencies:
       chalk: 5.6.2
       cli-spinners: 3.3.0
@@ -11622,6 +11688,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.2
 
+  '@inquirer/checkbox@4.3.2(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.13.5
+
   '@inquirer/checkbox@4.3.2(@types/node@25.0.3)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -11638,6 +11714,13 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@22.10.2)
     optionalDependencies:
       '@types/node': 22.10.2
+
+  '@inquirer/confirm@5.1.21(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+    optionalDependencies:
+      '@types/node': 22.13.5
 
   '@inquirer/confirm@5.1.21(@types/node@25.0.3)':
     dependencies:
@@ -11658,6 +11741,19 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 22.10.2
+
+  '@inquirer/core@10.3.2(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.13.5
 
   '@inquirer/core@10.3.2(@types/node@25.0.3)':
     dependencies:
@@ -11680,6 +11776,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.2
 
+  '@inquirer/editor@4.2.23(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.13.5)
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+    optionalDependencies:
+      '@types/node': 22.13.5
+
   '@inquirer/editor@4.2.23(@types/node@25.0.3)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.0.3)
@@ -11696,6 +11800,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.2
 
+  '@inquirer/expand@4.0.23(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.13.5
+
   '@inquirer/expand@4.0.23(@types/node@25.0.3)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.0.3)
@@ -11710,6 +11822,13 @@ snapshots:
       iconv-lite: 0.7.1
     optionalDependencies:
       '@types/node': 22.10.2
+
+  '@inquirer/external-editor@1.0.3(@types/node@22.13.5)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.1
+    optionalDependencies:
+      '@types/node': 22.13.5
 
   '@inquirer/external-editor@1.0.3(@types/node@25.0.3)':
     dependencies:
@@ -11727,6 +11846,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.2
 
+  '@inquirer/input@4.3.1(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+    optionalDependencies:
+      '@types/node': 22.13.5
+
   '@inquirer/input@4.3.1(@types/node@25.0.3)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.0.3)
@@ -11740,6 +11866,13 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@22.10.2)
     optionalDependencies:
       '@types/node': 22.10.2
+
+  '@inquirer/number@3.0.23(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+    optionalDependencies:
+      '@types/node': 22.13.5
 
   '@inquirer/number@3.0.23(@types/node@25.0.3)':
     dependencies:
@@ -11755,6 +11888,14 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@22.10.2)
     optionalDependencies:
       '@types/node': 22.10.2
+
+  '@inquirer/password@4.0.23(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+    optionalDependencies:
+      '@types/node': 22.13.5
 
   '@inquirer/password@4.0.23(@types/node@25.0.3)':
     dependencies:
@@ -11794,6 +11935,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.2
 
+  '@inquirer/prompts@7.8.0(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.13.5)
+      '@inquirer/confirm': 5.1.21(@types/node@22.13.5)
+      '@inquirer/editor': 4.2.23(@types/node@22.13.5)
+      '@inquirer/expand': 4.0.23(@types/node@22.13.5)
+      '@inquirer/input': 4.3.1(@types/node@22.13.5)
+      '@inquirer/number': 3.0.23(@types/node@22.13.5)
+      '@inquirer/password': 4.0.23(@types/node@22.13.5)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.13.5)
+      '@inquirer/search': 3.2.2(@types/node@22.13.5)
+      '@inquirer/select': 4.4.2(@types/node@22.13.5)
+    optionalDependencies:
+      '@types/node': 22.13.5
+
   '@inquirer/prompts@7.8.0(@types/node@25.0.3)':
     dependencies:
       '@inquirer/checkbox': 4.3.2(@types/node@25.0.3)
@@ -11817,6 +11973,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.2
 
+  '@inquirer/rawlist@4.1.11(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.13.5
+
   '@inquirer/rawlist@4.1.11(@types/node@25.0.3)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.0.3)
@@ -11833,6 +11997,15 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 22.10.2
+
+  '@inquirer/search@3.2.2(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.13.5
 
   '@inquirer/search@3.2.2(@types/node@25.0.3)':
     dependencies:
@@ -11853,6 +12026,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.2
 
+  '@inquirer/select@4.4.2(@types/node@22.13.5)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.13.5
+
   '@inquirer/select@4.4.2(@types/node@25.0.3)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -11866,6 +12049,10 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@22.10.2)':
     optionalDependencies:
       '@types/node': 22.10.2
+
+  '@inquirer/type@3.0.10(@types/node@22.13.5)':
+    optionalDependencies:
+      '@types/node': 22.13.5
 
   '@inquirer/type@3.0.10(@types/node@25.0.3)':
     optionalDependencies:
@@ -11944,7 +12131,44 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@lingo.dev/_compiler@0.9.0':
+    dependencies:
+      '@ai-sdk/anthropic': 3.0.9(zod@4.1.12)
+      '@ai-sdk/google': 3.0.6(zod@4.1.12)
+      '@ai-sdk/groq': 3.0.4(zod@4.1.12)
+      '@ai-sdk/mistral': 3.0.5(zod@4.1.12)
+      '@ai-sdk/openai': 3.0.7(zod@4.1.12)
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.28.5
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      '@lingo.dev/_sdk': 0.13.7
+      '@lingo.dev/_spec': 0.46.0
+      '@openrouter/ai-sdk-provider': 6.0.0-alpha.1(zod@4.1.12)
+      ai: 6.0.25(zod@4.1.12)
+      dedent: 1.7.0
+      dotenv: 16.4.5
+      fast-xml-parser: 5.3.2
+      ini: 5.0.0
+      lodash: 4.17.21
+      node-machine-id: 1.1.12
+      object-hash: 3.0.0
+      ollama-ai-provider-v2: 2.0.0(ai@6.0.25(zod@4.1.12))(zod@4.1.12)
+      posthog-node: 5.14.0
+      unplugin: 2.3.11
+      zod: 4.1.12
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+
   '@lingo.dev/_locales@0.3.1':
+    dependencies:
+      iso-639-3: 3.0.1
+
+  '@lingo.dev/_locales@0.3.3':
     dependencies:
       iso-639-3: 3.0.1
 
@@ -11954,9 +12178,27 @@ snapshots:
       lodash: 4.17.21
       next: 16.1.1(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
+  '@lingo.dev/_react@0.7.6(next@16.1.1(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+    dependencies:
+      js-cookie: 3.0.5
+      lodash: 4.17.21
+      next: 16.1.1(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+
   '@lingo.dev/_sdk@0.13.4':
     dependencies:
       '@lingo.dev/_spec': 0.44.4
+      '@paralleldrive/cuid2': 2.2.2
+      jsdom: 25.0.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+
+  '@lingo.dev/_sdk@0.13.7':
+    dependencies:
+      '@lingo.dev/_spec': 0.46.0
       '@paralleldrive/cuid2': 2.2.2
       jsdom: 25.0.1
       zod: 3.25.76
@@ -11971,6 +12213,57 @@ snapshots:
       '@lingo.dev/_locales': 0.3.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.0(zod@3.25.76)
+
+  '@lingo.dev/_spec@0.46.0':
+    dependencies:
+      '@lingo.dev/_locales': 0.3.3
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.0(zod@3.25.76)
+
+  '@lingo.dev/compiler@0.1.9(@types/node@22.13.5)(@types/react@19.2.7)(encoding@0.1.13)(next@16.1.1(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.1.12)':
+    dependencies:
+      '@ai-sdk/google': 3.0.1(zod@4.1.12)
+      '@ai-sdk/groq': 3.0.1(zod@4.1.12)
+      '@ai-sdk/mistral': 3.0.1(zod@4.1.12)
+      '@babel/core': 7.26.0
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.28.5
+      '@babel/preset-react': 7.26.3(@babel/core@7.26.0)
+      '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      '@formatjs/icu-messageformat-parser': 3.1.1
+      '@openrouter/ai-sdk-provider': 1.5.4(ai@6.0.3(zod@4.1.12))(zod@4.1.12)
+      ai: 6.0.3(zod@4.1.12)
+      ai-sdk-ollama: 3.0.0(ai@6.0.3(zod@4.1.12))(zod@4.1.12)
+      dotenv: 17.2.3
+      fast-xml-parser: 5.3.3
+      ini: 5.0.0
+      intl-messageformat: 11.0.6
+      lingo.dev: 0.122.1(@types/node@22.13.5)(@types/react@19.2.7)(encoding@0.1.13)(next@16.1.1(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      lodash: 4.17.21
+      node-machine-id: 1.1.12
+      posthog-node: 5.14.0
+      proper-lockfile: 4.1.2
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      ws: 8.18.3
+    optionalDependencies:
+      next: 16.1.1(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@biomejs/wasm-bundler'
+      - '@biomejs/wasm-web'
+      - '@cfworker/json-schema'
+      - '@types/node'
+      - '@types/react'
+      - babel-plugin-macros
+      - bufferutil
+      - canvas
+      - encoding
+      - react-devtools-core
+      - supports-color
+      - utf-8-validate
+      - zod
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -13522,7 +13815,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/chai@5.2.3':
     dependencies:
@@ -13535,19 +13828,19 @@ snapshots:
 
   '@types/cli-progress@3.11.6':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/debug@4.1.12':
     dependencies:
@@ -13569,14 +13862,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.7':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
   '@types/express-serve-static-core@5.1.0':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -13600,13 +13893,13 @@ snapshots:
 
   '@types/gettext-parser@4.0.4':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
       '@types/readable-stream': 4.0.23
 
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/hast@3.0.4':
     dependencies:
@@ -13622,7 +13915,7 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -13681,7 +13974,7 @@ snapshots:
   '@types/nodemailer@7.0.3':
     dependencies:
       '@aws-sdk/client-sesv2': 3.958.0
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
     transitivePeerDependencies:
       - aws-crt
 
@@ -13689,7 +13982,7 @@ snapshots:
 
   '@types/plist@3.0.5':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
       xmlbuilder: 15.1.1
 
   '@types/proper-lockfile@4.1.4':
@@ -13718,7 +14011,7 @@ snapshots:
 
   '@types/readable-stream@4.0.23':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/resolve@1.20.2': {}
 
@@ -13727,22 +14020,22 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
       '@types/send': 0.17.6
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/tinycolor2@1.4.6': {}
 
@@ -13754,11 +14047,11 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@types/xml2js@0.4.14':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 22.13.5
 
   '@typescript-eslint/eslint-plugin@8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -13966,6 +14259,18 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 7.3.0(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@5.0.4(vite@7.3.0(@types/node@22.13.5)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@rolldown/pluginutils': 1.0.0-beta.38
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 7.3.0(@types/node@22.13.5)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -16196,7 +16501,7 @@ snapshots:
       blacklist: 1.1.4
       prop-types: 15.8.1
 
-  ink-spinner@5.0.0(ink@4.2.0(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
+  ink-spinner@5.0.0(ink@4.2.0(react@19.2.3))(react@19.2.3):
     dependencies:
       cli-spinners: 2.9.2
       ink: 4.2.0(@types/react@19.2.7)(react@19.2.3)
@@ -16259,6 +16564,18 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.10.2
 
+  inquirer@12.6.0(@types/node@22.13.5):
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.13.5)
+      '@inquirer/prompts': 7.8.0(@types/node@22.13.5)
+      '@inquirer/type': 3.0.10(@types/node@22.13.5)
+      ansi-escapes: 4.3.2
+      mute-stream: 2.0.0
+      run-async: 3.0.0
+      rxjs: 7.8.2
+    optionalDependencies:
+      '@types/node': 22.13.5
+
   inquirer@12.6.0(@types/node@25.0.3):
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.0.3)
@@ -16274,6 +16591,14 @@ snapshots:
   interactive-commander@0.5.194(@types/node@22.10.2):
     dependencies:
       '@inquirer/prompts': 7.8.0(@types/node@22.10.2)
+      commander: 12.1.0
+      parse-my-command: 0.3.31
+    transitivePeerDependencies:
+      - '@types/node'
+
+  interactive-commander@0.5.194(@types/node@22.13.5):
+    dependencies:
+      '@inquirer/prompts': 7.8.0(@types/node@22.13.5)
       commander: 12.1.0
       parse-my-command: 0.3.31
     transitivePeerDependencies:
@@ -16805,7 +17130,7 @@ snapshots:
       '@biomejs/wasm-nodejs': 2.3.7
       '@datocms/cma-client-node': 4.0.1
       '@gitbeaker/rest': 39.34.3
-      '@inkjs/ui': 2.0.0(ink@4.2.0(@types/react@19.2.7)(react@19.2.3))
+      '@inkjs/ui': 2.0.0(ink@4.2.0(react@19.2.3))
       '@inquirer/prompts': 7.8.0(@types/node@25.0.3)
       '@lingo.dev/_compiler': 0.8.8(react@19.2.3)
       '@lingo.dev/_locales': 0.3.1
@@ -16846,7 +17171,7 @@ snapshots:
       ini: 5.0.0
       ink: 4.2.0(@types/react@19.2.7)(react@19.2.3)
       ink-progress-bar: 3.0.0
-      ink-spinner: 5.0.0(ink@4.2.0(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+      ink-spinner: 5.0.0(ink@4.2.0(react@19.2.3))(react@19.2.3)
       inquirer: 12.6.0(@types/node@25.0.3)
       interactive-commander: 0.5.194(@types/node@25.0.3)
       is-url: 1.2.4
@@ -16892,6 +17217,122 @@ snapshots:
       xpath: 0.0.34
       yaml: 2.8.1
       zod: 3.25.76
+    transitivePeerDependencies:
+      - '@biomejs/wasm-bundler'
+      - '@biomejs/wasm-web'
+      - '@cfworker/json-schema'
+      - '@types/node'
+      - '@types/react'
+      - babel-plugin-macros
+      - bufferutil
+      - canvas
+      - encoding
+      - next
+      - react-devtools-core
+      - supports-color
+      - utf-8-validate
+
+  lingo.dev@0.122.1(@types/node@22.13.5)(@types/react@19.2.7)(encoding@0.1.13)(next@16.1.1(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+    dependencies:
+      '@ai-sdk/anthropic': 3.0.9(zod@4.1.12)
+      '@ai-sdk/google': 3.0.6(zod@4.1.12)
+      '@ai-sdk/mistral': 3.0.5(zod@4.1.12)
+      '@ai-sdk/openai': 3.0.7(zod@4.1.12)
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.28.5
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      '@biomejs/js-api': 3.0.0(@biomejs/wasm-nodejs@2.3.7)
+      '@biomejs/wasm-nodejs': 2.3.7
+      '@datocms/cma-client-node': 4.0.1
+      '@gitbeaker/rest': 39.34.3
+      '@inkjs/ui': 2.0.0(ink@4.2.0(react@19.2.3))
+      '@inquirer/prompts': 7.8.0(@types/node@22.13.5)
+      '@lingo.dev/_compiler': 0.9.0
+      '@lingo.dev/_locales': 0.3.3
+      '@lingo.dev/_react': 0.7.6(next@16.1.1(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@lingo.dev/_sdk': 0.13.7
+      '@lingo.dev/_spec': 0.46.0
+      '@markdoc/markdoc': 0.5.4(@types/react@19.2.7)(react@19.2.3)
+      '@modelcontextprotocol/sdk': 1.22.0
+      '@openrouter/ai-sdk-provider': 6.0.0-alpha.1(zod@4.1.12)
+      '@paralleldrive/cuid2': 2.2.2
+      '@types/ejs': 3.1.5
+      ai: 6.0.25(zod@4.1.12)
+      bitbucket: 2.12.0(encoding@0.1.13)
+      chalk: 5.6.2
+      chokidar: 4.0.3
+      cli-progress: 3.12.0
+      cli-table3: 0.6.5
+      cors: 2.8.5
+      csv-parse: 5.6.0
+      csv-stringify: 6.6.0
+      date-fns: 4.1.0
+      dedent: 1.7.0
+      diff: 7.0.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      dotenv: 16.4.7
+      ejs: 3.1.10
+      express: 5.1.0
+      external-editor: 3.1.0
+      figlet: 1.9.4
+      flat: 6.0.1
+      gettext-parser: 8.0.0
+      glob: 11.1.0
+      gradient-string: 3.0.0
+      gray-matter: 4.0.3
+      htmlparser2: 10.0.0
+      ini: 5.0.0
+      ink: 4.2.0(@types/react@19.2.7)(react@19.2.3)
+      ink-progress-bar: 3.0.0
+      ink-spinner: 5.0.0(ink@4.2.0(react@19.2.3))(react@19.2.3)
+      inquirer: 12.6.0(@types/node@22.13.5)
+      interactive-commander: 0.5.194(@types/node@22.13.5)
+      is-url: 1.2.4
+      jsdom: 25.0.1
+      json5: 2.2.3
+      jsonc-parser: 3.3.1
+      jsonrepair: 3.13.1
+      listr2: 8.3.2
+      lodash: 4.17.21
+      marked: 15.0.6
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      node-machine-id: 1.1.12
+      node-webvtt: 1.9.4
+      object-hash: 3.0.0
+      octokit: 4.0.2
+      ollama-ai-provider-v2: 2.0.0(ai@6.0.25(zod@4.1.12))(zod@4.1.12)
+      open: 10.2.0
+      ora: 8.1.1
+      p-limit: 6.2.0
+      php-array-reader: 2.1.2
+      plist: 3.1.0
+      posthog-node: 5.14.0
+      prettier: 3.6.2
+      react: 19.2.3
+      rehype-stringify: 10.0.1
+      remark-disable-tokenizers: 1.1.1
+      remark-frontmatter: 5.0.0
+      remark-gfm: 4.0.1
+      remark-mdx: 3.1.1
+      remark-mdx-frontmatter: 5.2.0
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-stringify: 11.0.0
+      sax: 1.4.3
+      srt-parser-2: 1.2.3
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+      xliff: 6.2.2
+      xml2js: 0.6.2
+      xpath: 0.0.34
+      yaml: 2.8.1
+      zod: 4.1.12
     transitivePeerDependencies:
       - '@biomejs/wasm-bundler'
       - '@biomejs/wasm-web'
@@ -16995,6 +17436,10 @@ snapshots:
   lucide-react@0.545.0(react@19.2.0):
     dependencies:
       react: 19.2.0
+
+  lucide-react@0.545.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   lz-string@1.5.0: {}
 
@@ -17635,6 +18080,32 @@ snapshots:
       '@next/swc-win32-x64-msvc': 16.1.0
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.56.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.1.1(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@next/env': 16.1.1
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.9.11
+      caniuse-lite: 1.0.30001761
+      postcss: 8.4.31
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.2.3)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.1.1
+      '@next/swc-darwin-x64': 16.1.1
+      '@next/swc-linux-arm64-gnu': 16.1.1
+      '@next/swc-linux-arm64-musl': 16.1.1
+      '@next/swc-linux-x64-gnu': 16.1.1
+      '@next/swc-linux-x64-musl': 16.1.1
+      '@next/swc-win32-arm64-msvc': 16.1.1
+      '@next/swc-win32-x64-msvc': 16.1.1
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.57.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
   - "./action"
   - "./php/*"
   - "./scripts/*"
+  - "./community/*"


### PR DESCRIPTION
## Summary

A simple, fully multilingual Todo app demonstrating Lingo.dev's compile-time translation capabilities with React and Vite.

## Changes

- Added `/community/lingo-todo-app` - A React + Vite todo list application
- Integrated Lingo.dev compiler for automatic multilingual support (English, Spanish, French, German, Japanese)
- Implemented language switcher component with 5 language options
- Configured Vite with Lingo.dev compiler plugin for development and production builds
- Added comprehensive README with setup and usage instructions

## Features

- ✅ Create, complete, and delete tasks
- ✅ Real-time language switching with pseudotranslator
- ✅ Automatic translation of UI elements
- ✅ Task statistics (Total, Completed, Remaining)
- ✅ Dark modern UI with Lucide React icons

## Testing

**App tested locally:**

- [x] Task creation works (add new todos)
- [x] Task completion toggle works
- [x] Task deletion works
- [x] Language switcher translates UI in real-time
- [x] All dependencies install correctly
- [x] Dev server runs without errors

## Visuals

- Demo running on `http://localhost:3000`
- Pseudotranslations show compiler is processing text
- 5 language options available in header

## Checklist

- [x] Changeset added (if version bump needed)
- [x] README included with setup instructions
- [x] All dependencies properly configured
- [x] No breaking changes

## Prerequisites

- Node.js 18+
- pnpm

## Preview 
<img width="1351" height="925" alt="Screenshot 2026-01-22 194156" src="https://github.com/user-attachments/assets/9833dbe1-b1b5-494c-a679-d148981663c4" />


## How to Run
cd community/lingo-todo-app
pnpm install
pnpm dev

Related Issue : #1761 