### PR TITLE
feat: add mani-man cli wrapper to convert manuals in various lang #1761

### DIFF
--- a/.changeset/jolly-wasps-shop.md
+++ b/.changeset/jolly-wasps-shop.md
@@ -1,0 +1,2 @@
+
+man cli wrapper which uses lingo to convert english manual in various lang

--- a/community/mani-man-cli-wrapper/.gitignore
+++ b/community/mani-man-cli-wrapper/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+pnpm-lock.yaml
+.env

--- a/community/mani-man-cli-wrapper/README.md
+++ b/community/mani-man-cli-wrapper/README.md
@@ -1,0 +1,117 @@
+# man-lingo (mango/mani)
+
+Translate man pages and command help to any language using [Lingo.dev](https://lingo.dev) AI translation.
+
+## Features
+
+- 🌐 Translate any man page or `--help` output to your preferred language
+- ⚡ Smart caching for instant repeat lookups
+- 📄 Supports both `man` pages and `--help`/`-h` flags
+- 🎨 Preserves terminal formatting where possible
+
+## Working demo
+<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/40d7304b-978d-4af3-b017-2d870e25cd27" />
+<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/d781d79e-737c-43d6-97ba-f3297daaf7a8" />
+
+
+
+## Installation
+
+```bash
+# Clone and install dependencies
+npm install
+
+
+## Setup
+
+You need a Lingo.dev API key to use this tool:
+
+1. Sign up at [lingo.dev](https://lingo.dev)
+2. Get your API key from the dashboard
+3. Set the environment variable:
+
+LINGODOTDEV_API_KEY=your_api_key_here
+LINGO_TARGET_LANG=hi  # Hindi (default)
+
+```
+
+```
+# Run locally
+npm run dev  git -l es  # understand git manual in spanish
+
+# or
+npm run dev  git -l hi  # understand git manual in hindi
+
+#or
+
+# Build the project
+npm run build
+
+# Link globally (optional)
+npm link
+
+# Translate git man page to Hindi (default)
+mani git
+
+# Translate git commit help to Spanish
+mani git commit --lang es
+
+# Translate ls man page to French
+mani ls --lang fr
+
+# Force re-translation (bypass cache)
+mani git --force
+
+# Show translation progress
+mani git --progress
+
+# Clear all cached translations
+mani --clear-cache
+```
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-l, --lang <locale>` | Target language locale | `hi` (Hindi) |
+| `-f, --force` | Bypass cache and re-translate | `false` |
+| `--no-cache` | Disable caching for this request | - |
+| `-p, --progress` | Show translation progress | `false` |
+| `--clear-cache` | Clear all cached translations | - |
+
+## How It Works
+
+1. **Execute**: Runs `man <command>` or `<command> --help` to get help text
+2. **Cache Check**: Looks for existing translation in `~/.lingo-man/cache/`
+3. **Translate**: Sends text to Lingo.dev API for AI translation
+4. **Cache Save**: Stores translation for future use
+5. **Display**: Shows translated output
+
+## Supported Languages
+
+Lingo.dev supports many languages. Use standard locale codes:
+
+- `hi` - Hindi
+- `es` - Spanish
+- `fr` - French
+- `de` - German
+- `ja` - Japanese
+- `zh` - Chinese
+- `ar` - Arabic
+- `pt` - Portuguese
+- And many more...
+
+
+## Cache Location
+
+Translations are cached at:
+```
+~/.lingo-man/cache/
+```
+
+Each translation is stored as a JSON file with a hashed filename based on the command, locale, and content hash.
+
+## License
+
+MIT
+

--- a/community/mani-man-cli-wrapper/package.json
+++ b/community/mani-man-cli-wrapper/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "lingo-man",
+  "version": "1.0.0",
+  "description": "Translate man pages and command help using Lingo.dev AI",
+  "bin": {
+    "mani": "./dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/cli.js",
+    "dev": "pnpx tsx src/cli.ts",
+    "mani": "./dist/cli.js"
+  },
+  "keywords": [
+    "man",
+    "translate",
+    "i18n",
+    "cli",
+    "lingo"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "commander": "^12.1.0",
+    "dotenv": "^17.2.3",
+    "lingo.dev": "^0.125.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/community/mani-man-cli-wrapper/src/cache.ts
+++ b/community/mani-man-cli-wrapper/src/cache.ts
@@ -1,0 +1,115 @@
+import { createHash } from "crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export interface CacheEntry {
+  command: string;
+  targetLocale: string;
+  originalHash: string;
+  translatedContent: string;
+  timestamp: number;
+}
+
+const CACHE_DIR = join(homedir(), ".lingo-man", "cache");
+
+/**
+ * Ensures the cache directory exists.
+ */
+function ensureCacheDir(): void {
+  if (!existsSync(CACHE_DIR)) {
+    mkdirSync(CACHE_DIR, { recursive: true });
+  }
+}
+
+/**
+ * Generates a unique cache key based on command, locale, and content.
+ */
+function generateCacheKey(
+  command: string,
+  targetLocale: string,
+  content: string
+): string {
+  const contentHash = createHash("sha256").update(content).digest("hex").slice(0, 16);
+  const keyData = `${command}:${targetLocale}:${contentHash}`;
+  return createHash("sha256").update(keyData).digest("hex");
+}
+
+/**
+ * Gets the file path for a cache key.
+ */
+function getCacheFilePath(cacheKey: string): string {
+  return join(CACHE_DIR, `${cacheKey}.json`);
+}
+
+/**
+ * Retrieves a cached translation if it exists.
+ */
+export function getFromCache(
+  command: string,
+  targetLocale: string,
+  content: string
+): string | null {
+  ensureCacheDir();
+
+  const cacheKey = generateCacheKey(command, targetLocale, content);
+  const filePath = getCacheFilePath(cacheKey);
+
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const data = readFileSync(filePath, "utf-8");
+    const entry: CacheEntry = JSON.parse(data);
+
+    // Verify the content hash matches
+    const contentHash = createHash("sha256").update(content).digest("hex").slice(0, 16);
+    if (entry.originalHash === contentHash) {
+      return entry.translatedContent;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Saves a translation to the cache.
+ */
+export function saveToCache(
+  command: string,
+  targetLocale: string,
+  originalContent: string,
+  translatedContent: string
+): void {
+  ensureCacheDir();
+
+  const contentHash = createHash("sha256")
+    .update(originalContent)
+    .digest("hex")
+    .slice(0, 16);
+  const cacheKey = generateCacheKey(command, targetLocale, originalContent);
+  const filePath = getCacheFilePath(cacheKey);
+
+  const entry: CacheEntry = {
+    command,
+    targetLocale,
+    originalHash: contentHash,
+    translatedContent,
+    timestamp: Date.now(),
+  };
+
+  writeFileSync(filePath, JSON.stringify(entry, null, 2), "utf-8");
+}
+
+/**
+ * Clears all cached translations.
+ */
+export function clearCache(): void {
+  const { rmSync } = require("fs");
+  if (existsSync(CACHE_DIR)) {
+    rmSync(CACHE_DIR, { recursive: true, force: true });
+  }
+}

--- a/community/mani-man-cli-wrapper/src/cli.ts
+++ b/community/mani-man-cli-wrapper/src/cli.ts
@@ -1,0 +1,90 @@
+
+// #!/usr/bin/env node
+
+
+import { Command } from "commander";
+import { executeHelpCommand } from "./executor";
+import { getFromCache, saveToCache, clearCache } from "./cache";
+import { translateLargeText } from "./translator";
+import { stripAnsi, translateWithFormatting } from "./formatter";
+import { runStreamingTranslation, getSectionCount } from "./streamer";
+
+const program = new Command();
+
+program
+  .name("mani")
+  .description("Translate man pages and command help using Lingo.dev AI")
+  .version("1.0.0")
+  .argument("<command...>", "Command to get help for (e.g., git commit)")
+  .option("-l, --lang <locale>", "Target language locale", process.env.LINGO_TARGET_LANG || "hi")
+  .option("-f, --force", "Force re-translation (bypass cache)", false)
+  .option("--no-cache", "Disable caching entirely")
+  .option("--clear-cache", "Clear all cached translations and exit")
+  .option("-p, --progress", "Show translation progress", false)
+  .action(async (commandArgs: string[], options) => {
+    try {
+      // Handle cache clear
+      if (options.clearCache) {
+        clearCache();
+        console.log("✓ Cache cleared successfully");
+        return;
+      }
+
+
+      const { lang, force, cache, progress } = options;
+
+      console.log(`🔍 Getting help for: ${commandArgs.join(" ")}`);
+
+      // Step 1: Execute the command to get help text
+      const result = executeHelpCommand(commandArgs);
+
+      if (!result.success) {
+        console.error(`\n❌ ${result.output}`);
+        process.exit(1);
+      }
+
+      console.log(`✓ Got help from: ${result.command}`);
+
+      // Step 2: Check cache (if enabled and not forcing)
+      const commandKey = commandArgs.join("-");
+      if (cache && !force) {
+        const cached = getFromCache(commandKey, lang, result.output);
+        if (cached) {
+          console.log(`✓ Using cached translation (${lang})\n`);
+          console.log(cached);
+          return;
+        }
+      }
+
+      console.log(`🌐 Translating to ${lang}...`);
+
+      // Step 3: Translate the content
+      const plainText = stripAnsi(result.output);
+      
+      // Streaming mode - translate and display in chunks
+      
+        console.log(`📊 Total sections: ${getSectionCount(plainText)}`);
+        await runStreamingTranslation(plainText, lang);
+        return; // Streaming mode handles its own exit
+      
+      let translatedText: string;
+ 
+      // Step 4: Save to cache (if enabled)
+      if (cache) {
+        saveToCache(commandKey, lang, result.output, translatedText);
+        console.log(`✓ Translation cached`);
+      }
+
+      // Step 5: Display translated output
+      console.log(`\n${"─".repeat(60)}\n`);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error(`\n❌ Error: ${error.message}`);
+      } else {
+        console.error("\n❌ An unexpected error occurred");
+      }
+      process.exit(1);
+    }
+  });
+
+program.parse();

--- a/community/mani-man-cli-wrapper/src/executor.ts
+++ b/community/mani-man-cli-wrapper/src/executor.ts
@@ -1,0 +1,121 @@
+import { execSync } from "child_process";
+
+export interface ExecutionResult {
+  success: boolean;
+  output: string;
+  command: string;
+}
+
+/**
+ * Executes a help command and captures its output.
+ * Tries multiple strategies:
+ * 1. man <command>
+ * 2. <command> --help
+ * 3. <command> -h
+ */
+export function executeHelpCommand(args: string[]): ExecutionResult {
+  const command = args[0];
+  const subcommand = args.slice(1).join(" ");
+
+  // Strategy 1: Try man page
+  const manResult = tryManPage(command, subcommand);
+  if (manResult.success) {
+    return manResult;
+  }
+
+  // Strategy 2: Try --help flag
+  const helpResult = tryHelpFlag(args, "--help");
+  if (helpResult.success) {
+    return helpResult;
+  }
+
+  // Strategy 3: Try -h flag
+  const shortHelpResult = tryHelpFlag(args, "-h");
+  if (shortHelpResult.success) {
+    return shortHelpResult;
+  }
+
+  // Return the man page error as fallback
+  return {
+    success: false,
+    output: `Could not get help for command: ${args.join(" ")}\nTried:\n  - man ${command} ${subcommand}\n  - ${args.join(" ")} --help\n  - ${args.join(" ")} -h`,
+    command: args.join(" "),
+  };
+}
+
+function tryManPage(command: string, subcommand: string): ExecutionResult {
+  try {
+    // For subcommands like "git commit", try "man git-commit" first
+    const manCommand = subcommand
+      ? `${command}-${subcommand.replace(/\s+/g, "-")}`
+      : command;
+
+    const output = execSync(`man ${manCommand}`, {
+      encoding: "utf-8",
+      env: { ...process.env, PAGER: "cat", MANPAGER: "cat" },
+      maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large man pages
+      timeout: 30000,
+    });
+
+    return {
+      success: true,
+      output: output.trim(),
+      command: `man ${manCommand}`,
+    };
+  } catch {
+    // If subcommand format failed, try just the main command
+    if (subcommand) {
+      try {
+        const output = execSync(`man ${command}`, {
+          encoding: "utf-8",
+          env: { ...process.env, PAGER: "cat", MANPAGER: "cat" },
+          maxBuffer: 10 * 1024 * 1024,
+          timeout: 30000,
+        });
+
+        return {
+          success: true,
+          output: output.trim(),
+          command: `man ${command}`,
+        };
+      } catch {
+        return { success: false, output: "", command: `man ${command}` };
+      }
+    }
+
+    return { success: false, output: "", command: `man ${command}` };
+  }
+}
+
+function tryHelpFlag(args: string[], flag: string): ExecutionResult {
+  const fullCommand = [...args, flag].join(" ");
+
+  try {
+    const output = execSync(fullCommand, {
+      encoding: "utf-8",
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 30000,
+    });
+
+    return {
+      success: true,
+      output: output.trim(),
+      command: fullCommand,
+    };
+  } catch (error: unknown) {
+    // Some commands print help to stderr and exit with non-zero
+    if (error && typeof error === "object" && "stdout" in error) {
+      const execError = error as { stdout?: string; stderr?: string };
+      const combinedOutput = (execError.stdout || "") + (execError.stderr || "");
+      if (combinedOutput.trim().length > 50) {
+        return {
+          success: true,
+          output: combinedOutput.trim(),
+          command: fullCommand,
+        };
+      }
+    }
+
+    return { success: false, output: "", command: fullCommand };
+  }
+}

--- a/community/mani-man-cli-wrapper/src/formatter.ts
+++ b/community/mani-man-cli-wrapper/src/formatter.ts
@@ -1,0 +1,156 @@
+/**
+ * ANSI escape sequence pattern for terminal formatting.
+ * Matches sequences like \x1b[1m (bold), \x1b[0m (reset), etc.
+ */
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
+
+interface FormatMarker {
+  code: string;
+  position: number;
+  relativePosition: number; // Position as percentage of total text
+}
+
+/**
+ * Strips all ANSI escape sequences from text.
+ */
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_PATTERN, "");
+}
+
+/**
+ * Extracts ANSI escape sequences and their positions from text.
+ */
+function extractFormatMarkers(text: string): FormatMarker[] {
+  const markers: FormatMarker[] = [];
+  const plainText = stripAnsi(text);
+  const totalLength = plainText.length || 1;
+
+  let match: RegExpExecArray | null;
+  let plainPosition = 0;
+
+  // Reset the regex
+  ANSI_PATTERN.lastIndex = 0;
+
+  let lastIndex = 0;
+  const workingText = text;
+
+  while ((match = ANSI_PATTERN.exec(workingText)) !== null) {
+    // Calculate plain text position by counting non-ANSI chars before this match
+    const textBefore = workingText.slice(lastIndex, match.index);
+    plainPosition += stripAnsi(textBefore).length;
+
+    markers.push({
+      code: match[0],
+      position: plainPosition,
+      relativePosition: plainPosition / totalLength,
+    });
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  return markers;
+}
+
+/**
+ * Applies format markers to translated text based on relative positions.
+ * Since translation changes text length, we use proportional repositioning.
+ */
+function applyFormatMarkers(text: string, markers: FormatMarker[]): string {
+  if (markers.length === 0) {
+    return text;
+  }
+
+  const totalLength = text.length || 1;
+  const result: string[] = [];
+  let lastPosition = 0;
+
+  // Sort markers by relative position
+  const sortedMarkers = [...markers].sort(
+    (a, b) => a.relativePosition - b.relativePosition
+  );
+
+  for (const marker of sortedMarkers) {
+    // Calculate new position proportionally
+    const newPosition = Math.round(marker.relativePosition * totalLength);
+    const clampedPosition = Math.max(lastPosition, Math.min(newPosition, totalLength));
+
+    // Add text before this marker
+    if (clampedPosition > lastPosition) {
+      result.push(text.slice(lastPosition, clampedPosition));
+    }
+
+    // Add the ANSI code
+    result.push(marker.code);
+    lastPosition = clampedPosition;
+  }
+
+  // Add remaining text
+  if (lastPosition < totalLength) {
+    result.push(text.slice(lastPosition));
+  }
+
+  return result.join("");
+}
+
+/**
+ * Translates text while attempting to preserve ANSI formatting.
+ * 
+ * Strategy:
+ * 1. Extract format markers with relative positions
+ * 2. Strip ANSI codes for translation
+ * 3. Translate plain text
+ * 4. Reapply format markers at proportional positions
+ */
+export async function translateWithFormatting(
+  text: string,
+  translateFn: (plainText: string) => Promise<string>
+): Promise<string> {
+  // Extract format markers
+  const markers = extractFormatMarkers(text);
+
+  // Strip ANSI codes for translation
+  const plainText = stripAnsi(text);
+
+  // Translate the plain text
+  const translatedText = await translateFn(plainText);
+
+  // If no formatting was present, return as-is
+  if (markers.length === 0) {
+    return translatedText;
+  }
+
+  // Reapply formatting at proportional positions
+  return applyFormatMarkers(translatedText, markers);
+}
+
+/**
+ * Simple line-by-line formatting preservation.
+ * Better for man pages where formatting is typically line-scoped.
+ */
+export async function translateLinesWithFormatting(
+  text: string,
+  translateFn: (plainText: string) => Promise<string>
+): Promise<string> {
+  const lines = text.split("\n");
+  const translatedLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.trim() === "") {
+      translatedLines.push(line);
+      continue;
+    }
+
+    // Check if line has formatting
+    const hasFormatting = ANSI_PATTERN.test(line);
+
+    if (hasFormatting) {
+      const translated = await translateWithFormatting(line, translateFn);
+      translatedLines.push(translated);
+    } else {
+      const translated = await translateFn(line);
+      translatedLines.push(translated);
+    }
+  }
+
+  return translatedLines.join("\n");
+}

--- a/community/mani-man-cli-wrapper/src/streamer.ts
+++ b/community/mani-man-cli-wrapper/src/streamer.ts
@@ -1,0 +1,184 @@
+import { translateText } from "./translator";
+import * as readline from "readline";
+
+const CHUNK_SIZE = 5; // Number of paragraphs to translate at a time
+
+interface StreamState {
+  paragraphs: string[];
+  currentIndex: number;
+  translatedBuffer: string[];
+  isTranslating: boolean;
+  isDone: boolean;
+}
+
+/**
+ * Creates a stream state from the input text
+ */
+export function createStreamState(text: string): StreamState {
+  // Split into paragraphs (double newlines or significant whitespace)
+  const paragraphs = text.split(/\n\s*\n/).filter(p => p.trim() !== "");
+  
+  return {
+    paragraphs,
+    currentIndex: 0,
+    translatedBuffer: [],
+    isTranslating: false,
+    isDone: false,
+  };
+}
+
+/**
+ * Translates the next chunk of paragraphs
+ */
+async function translateNextChunk(
+  state: StreamState,
+  targetLocale: string
+): Promise<string[]> {
+  const endIndex = Math.min(state.currentIndex + CHUNK_SIZE, state.paragraphs.length);
+  const chunk = state.paragraphs.slice(state.currentIndex, endIndex);
+  
+  const translated: string[] = [];
+  
+  for (const paragraph of chunk) {
+    if (paragraph.trim() === "") {
+      translated.push(paragraph);
+    } else {
+      const result = await translateText(paragraph, targetLocale);
+      translated.push(result);
+    }
+  }
+  
+  state.currentIndex = endIndex;
+  state.isDone = state.currentIndex >= state.paragraphs.length;
+  
+  return translated;
+}
+
+/**
+ * Runs the interactive streaming translation
+ */
+export async function runStreamingTranslation(
+  text: string,
+  targetLocale: string
+): Promise<void> {
+  const state = createStreamState(text);
+  
+  // Setup readline for capturing user input
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  // Enable raw mode to capture keystrokes immediately
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+  }
+  
+  console.log(`\n${"─".repeat(60)}`);
+  console.log(`📖 Streaming translation mode (${state.paragraphs.length} sections)`);
+  console.log(`   Press ENTER/SPACE for more, 'q' or Ctrl+C to quit`);
+  console.log(`${"─".repeat(60)}\n`);
+
+  // Translate and display first chunk immediately
+  state.isTranslating = true;
+  const firstChunk = await translateNextChunk(state, targetLocale);
+  state.translatedBuffer.push(...firstChunk);
+  console.log(firstChunk.join("\n\n"));
+  state.isTranslating = false;
+
+  if (state.isDone) {
+    console.log(`\n${"─".repeat(60)}`);
+    console.log("✓ End of translation");
+    rl.close();
+    process.exit(0);
+  }
+
+  // Pre-fetch next chunk in background
+  let prefetchPromise: Promise<string[]> | null = null;
+  const startPrefetch = () => {
+    if (!state.isDone && !prefetchPromise) {
+      prefetchPromise = translateNextChunk(state, targetLocale);
+    }
+  };
+  startPrefetch();
+
+  // Show continuation prompt
+  const showPrompt = () => {
+    const remaining = state.paragraphs.length - state.currentIndex + (prefetchPromise ? CHUNK_SIZE : 0);
+    const progress = Math.round(((state.paragraphs.length - remaining) / state.paragraphs.length) * 100);
+    process.stdout.write(`\n[${progress}% - ${remaining} sections remaining] Press ENTER for more, 'q' to quit: `);
+  };
+
+  showPrompt();
+
+  // Handle input
+  process.stdin.on("data", async (key: Buffer) => {
+    const char = key.toString();
+    
+    // Handle quit commands
+    if (char === "q" || char === "Q" || char === "\u0003" || char === "\u001A") {
+      // q, Q, Ctrl+C, Ctrl+Z
+      console.log("\n\n👋 Translation stopped by user");
+      rl.close();
+      process.exit(0);
+    }
+    
+    // Handle continue commands (Enter, Space, arrow down)
+    if (char === "\r" || char === "\n" || char === " " || char === "\u001B[B") {
+      if (state.isDone && !prefetchPromise) {
+        console.log(`\n\n${"─".repeat(60)}`);
+        console.log("✓ End of translation");
+        rl.close();
+        process.exit(0);
+      }
+
+      // Clear the prompt line
+      process.stdout.write("\r" + " ".repeat(80) + "\r");
+
+      // Wait for prefetched content or fetch new
+      let content: string[];
+      if (prefetchPromise) {
+        content = await prefetchPromise;
+        prefetchPromise = null;
+      } else {
+        state.isTranslating = true;
+        content = await translateNextChunk(state, targetLocale);
+        state.isTranslating = false;
+      }
+
+      // Display content
+      console.log("\n" + content.join("\n\n"));
+      
+      // Start prefetching next chunk
+      if (!state.isDone) {
+        startPrefetch();
+        showPrompt();
+      } else {
+        console.log(`\n${"─".repeat(60)}`);
+        console.log("✓ End of translation");
+        rl.close();
+        process.exit(0);
+      }
+    }
+  });
+
+  // Handle process signals
+  process.on("SIGINT", () => {
+    console.log("\n\n👋 Translation interrupted");
+    rl.close();
+    process.exit(0);
+  });
+
+  process.on("SIGTSTP", () => {
+    console.log("\n\n👋 Translation suspended");
+    rl.close();
+    process.exit(0);
+  });
+}
+
+/**
+ * Gets the total number of sections in the text
+ */
+export function getSectionCount(text: string): number {
+  return text.split(/\n\s*\n/).filter(p => p.trim() !== "").length;
+}

--- a/community/mani-man-cli-wrapper/src/translator.ts
+++ b/community/mani-man-cli-wrapper/src/translator.ts
@@ -1,0 +1,92 @@
+import { LingoDotDevEngine } from "lingo.dev/sdk";
+import * as dotenv from 'dotenv';
+dotenv.config({quiet: true });
+
+let engine: LingoDotDevEngine | null = null;
+
+/**
+ * Initializes the Lingo.dev engine with API key.
+ */
+function getEngine(): LingoDotDevEngine {
+  if (engine) {
+    return engine;
+  }
+
+  const apiKey = process.env.LINGODOTDEV_API_KEY;
+
+  if (!apiKey) {
+    throw new Error(
+      "LINGODOTDEV_API_KEY environment variable is not set.\n" +
+        "Please set it with your Lingo.dev API key:\n" +
+        "  export LINGODOTDEV_API_KEY=your_api_key_here\n\n" +
+        "Get your API key at: https://lingo.dev"
+    );
+  }
+
+  engine = new LingoDotDevEngine({
+    apiKey,
+  });
+
+  return engine;
+}
+
+/**
+ * Translates text to the target locale.
+ */
+export async function translateText(
+  text: string,
+  targetLocale: string,
+  sourceLocale: string = "en"
+): Promise<string> {
+  const lingoDotDev = getEngine();
+
+  try {
+    const result = await lingoDotDev.localizeText(text, {
+      sourceLocale,
+      targetLocale,
+    });
+
+    return result;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      throw new Error(`Translation failed: ${error.message}`);
+    }
+    throw new Error("Translation failed with unknown error");
+  }
+}
+
+/**
+ * Translates text in chunks to handle large man pages.
+ * Splits by paragraphs to maintain context.
+ */
+export async function translateLargeText(
+  text: string,
+  targetLocale: string,
+  onProgress?: (percent: number) => void
+): Promise<string> {
+  // Split into paragraphs (double newlines or significant whitespace)
+  const paragraphs = text.split(/\n\s*\n/);
+  const translatedParagraphs: string[] = [];
+
+  for (let i = 0; i < paragraphs.length; i++) {
+    const paragraph = paragraphs[i];
+
+    // Skip empty paragraphs
+    if (paragraph.trim() === "") {
+      translatedParagraphs.push(paragraph);
+      continue;
+    }
+
+    // Translate the paragraph
+    const translated = await translateText(paragraph, targetLocale);
+    translatedParagraphs.push(translated);
+
+    // Report progress
+    if (onProgress) {
+      const percent = Math.round(((i + 1) / paragraphs.length) * 100);
+      onProgress(percent);
+    }
+  }
+
+  return translatedParagraphs.join("\n\n");
+}

--- a/community/mani-man-cli-wrapper/tsconfig.json
+++ b/community/mani-man-cli-wrapper/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Add man cli wrapper for internalization of every command  #1761 

- 🌐 Translate any man page or `--help` output to your preferred language
- ⚡ Smart caching for instant repeat lookups
- 📄 Supports both `man` pages and `--help`/`-h` flags
- 🎨 Preserves terminal formatting where possible

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/40d7304b-978d-4af3-b017-2d870e25cd27" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/d781d79e-737c-43d6-97ba-f3297daaf7a8" />

## Changes

- added community project using lingo.dev js sdk


## Checklist

- [X] Changeset added (if version bump needed)
- Tests cover business logic (not just happy path)
- [X] No breaking changes (or documented below)

Closes #[1761]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI tool to translate man pages and command help into many languages
  * Streaming review mode with chunked display and progress prompts
  * Local caching to skip redundant translations
  * Formatting preservation so terminal styling remains intact

* **Documentation**
  * Full README with installation, API key setup, usage examples, flags, and license

* **Chores**
  * Project scaffolding and package configuration added; common files ignored (build/env artifacts)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->