### PR TITLE
fix(new-compiler): prevent ELOCKED errors during parallel builds

### DIFF
--- a/.changeset/major-weeks-sing.md
+++ b/.changeset/major-weeks-sing.md
@@ -1,0 +1,5 @@
+---
+"@lingo.dev/compiler": patch
+---
+
+Fixed metadata file lock contention errors (ELOCKED) during parallel builds by increasing lock retry count and timeouts

--- a/packages/new-compiler/src/metadata/manager.ts
+++ b/packages/new-compiler/src/metadata/manager.ts
@@ -168,11 +168,11 @@ export class MetadataManager {
 
     const release = await lockfile.lock(this.filePath, {
       retries: {
-        retries: 10,
+        retries: 20,
         minTimeout: 50,
-        maxTimeout: 1000,
+        maxTimeout: 2000,
       },
-      stale: 2000,
+      stale: 5000,
     });
 
     try {


### PR DESCRIPTION
## Summary

Fixed metadata file lock contention errors (ELOCKED) during parallel builds by increasing lock retry count and timeouts   

## Changes

- Increased metadata file lock retry count (10 → 20) to handle more concurrent workers
- Increased maxTimeout (1s → 2s) and stale threshold (2s → 5s) to prevent false lock expiration

## Testing

**Tests performed:**

- [x] Verified that no ELOCKED errors occur during the build process.
- [x] All tests pass locally

## Checklist

- [x] Changeset added (if version bump needed)
- [x] No breaking changes (or documented below)

Closes https://github.com/lingodotdev/lingo.dev/issues/1636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file lock contention errors that occurred during parallel builds, improving reliability and stability when running concurrent compilation tasks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->