### PR TITLE
feat(cli): add preservedKeys

### DIFF
--- a/.changeset/crisp-signs-itch.md
+++ b/.changeset/crisp-signs-itch.md
@@ -1,0 +1,6 @@
+---
+"@lingo.dev/_spec": patch
+"lingo.dev": patch
+---
+
+Add `preservedKeys` configuration option to buckets. Preserved keys are added to targets using source values as placeholders, but once present in the target file, they are never overwritten by the CLI. This is useful for values like URLs or emails that should be copied initially but then customized per locale.

--- a/packages/cli/demo/json/en/example.json
+++ b/packages/cli/demo/json/en/example.json
@@ -10,14 +10,8 @@
   "author": {
     "name": "John Doe"
   },
-  "contributors": [
-    { "name": "Alice" },
-    { "name": "Bob" }
-  ],
-  "messages": [
-    "Welcome to MyApp",
-    "Hello, world!"
-  ],
+  "contributors": [{ "name": "Alice" }, { "name": "Bob" }],
+  "messages": ["Welcome to MyApp", "Hello, world!"],
   "config": {
     "theme": {
       "primary": "Blue theme"
@@ -32,6 +26,9 @@
     }
   ],
   "locked_key_1": "This value is locked and should not be changed",
-  "ignored_key_1": "This value is ignored and should not appear in target locales"
-
+  "ignored_key_1": "This value is ignored and should not appear in target locales",
+  "preserved_key_1": "this value is preserved and should not be overwritten",
+  "legal": {
+    "preserved_nested": "this value is preserved and should not be overwritten"
+  }
 }

--- a/packages/cli/demo/json/es/example.json
+++ b/packages/cli/demo/json/es/example.json
@@ -32,5 +32,9 @@
       "nested_message": "Texto anidado"
     }
   ],
-  "locked_key_1": "This value is locked and should not be changed"
+  "locked_key_1": "This value is locked and should not be changed",
+  "preserved_key_1": "this value is preserved and should not be overwritten",
+  "legal": {
+    "preserved_nested": "this value is preserved and should not be overwritten"
+  }
 }

--- a/packages/cli/demo/json/i18n.json
+++ b/packages/cli/demo/json/i18n.json
@@ -1,17 +1,14 @@
 {
-  "version": "1.10",
+  "version": "1.12",
   "locale": {
     "source": "en",
-    "targets": [
-      "es"
-    ]
+    "targets": ["es"]
   },
   "buckets": {
     "json": {
-      "include": [
-        "./[locale]/example.json"
-      ],
-      "lockedKeys": ["locked_key_1"]
+      "include": ["./[locale]/example.json"],
+      "lockedKeys": ["locked_key_1"],
+      "preservedKeys": ["preserved_key_1", "legal/preserved_nested"]
     }
   },
   "$schema": "https://lingo.dev/schema/i18n.json"

--- a/packages/cli/demo/json/i18n.lock
+++ b/packages/cli/demo/json/i18n.lock
@@ -14,3 +14,5 @@ checksums:
     config/theme/primary: 7535a3779d6934ea8ecf18f5cb5b93fd
     mixed_array/0: 001b5b003d96c133534f5907abffdf77
     mixed_array/3/nested_message: 5f0782dfc5993e99890c0475bc295a30
+    ignored_key_1: 386cb6c3c496982b059671768905d66e
+    legal/preserved_nested: 1f22d279b6be8d261e125e54c5a6cb64

--- a/packages/cli/i18n.json
+++ b/packages/cli/i18n.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10",
+  "version": "1.12",
   "locale": {
     "source": "en",
     "targets": ["es"]
@@ -34,7 +34,8 @@
     "json": {
       "include": ["demo/json/[locale]/example.json"],
       "lockedKeys": ["locked_key_1"],
-      "ignoredKeys": ["ignored_key_1"]
+      "ignoredKeys": ["ignored_key_1"],
+      "preservedKeys": ["preserved_key_1", "legal/preserved_nested"]
     },
     "jsonc": {
       "include": ["demo/jsonc/[locale]/example.jsonc"],

--- a/packages/cli/src/cli/cmd/run/_types.ts
+++ b/packages/cli/src/cli/cmd/run/_types.ts
@@ -32,6 +32,7 @@ export type CmdRunTask = {
   lockedKeys: string[];
   lockedPatterns: string[];
   ignoredKeys: string[];
+  preservedKeys: string[];
   onlyKeys: string[];
   formatter?: "prettier" | "biome";
 };

--- a/packages/cli/src/cli/cmd/run/execute.ts
+++ b/packages/cli/src/cli/cmd/run/execute.ts
@@ -163,6 +163,7 @@ function createLoaderForTask(assignedTask: CmdRunTask) {
     assignedTask.lockedKeys,
     assignedTask.lockedPatterns,
     assignedTask.ignoredKeys,
+    assignedTask.preservedKeys,
   );
   bucketLoader.setDefaultLocale(assignedTask.sourceLocale);
 

--- a/packages/cli/src/cli/cmd/run/frozen.ts
+++ b/packages/cli/src/cli/cmd/run/frozen.ts
@@ -64,6 +64,7 @@ export default async function frozen(input: CmdRunContext) {
                   bucket.lockedKeys,
                   bucket.lockedPatterns,
                   bucket.ignoredKeys,
+                  bucket.preservedKeys,
                 );
                 loader.setDefaultLocale(resolvedSourceLocale);
                 await loader.init();
@@ -103,6 +104,7 @@ export default async function frozen(input: CmdRunContext) {
                 bucket.lockedKeys,
                 bucket.lockedPatterns,
                 bucket.ignoredKeys,
+                bucket.preservedKeys,
               );
               loader.setDefaultLocale(resolvedSourceLocale);
               await loader.init();

--- a/packages/cli/src/cli/cmd/run/plan.ts
+++ b/packages/cli/src/cli/cmd/run/plan.ts
@@ -133,6 +133,7 @@ export default async function plan(
                   lockedKeys: bucket.lockedKeys || [],
                   lockedPatterns: bucket.lockedPatterns || [],
                   ignoredKeys: bucket.ignoredKeys || [],
+                  preservedKeys: bucket.preservedKeys || [],
                   onlyKeys: input.flags.key || [],
                   formatter: input.config!.formatter,
                 });

--- a/packages/cli/src/cli/loaders/index.ts
+++ b/packages/cli/src/cli/loaders/index.ts
@@ -44,6 +44,7 @@ import createLocalizableMdxDocumentLoader from "./mdx2/localizable-document";
 import createMdxSectionsSplit2Loader from "./mdx2/sections-split-2";
 import createLockedPatternsLoader from "./locked-patterns";
 import createIgnoredKeysLoader from "./ignored-keys";
+import createPreservedKeysLoader from "./preserved-keys";
 import createEjsLoader from "./ejs";
 import createTwigLoader from "./twig";
 import createEnsureKeyOrderLoader from "./ensure-key-order";
@@ -90,6 +91,7 @@ export default function createBucketLoader(
   lockedKeys?: string[],
   lockedPatterns?: string[],
   ignoredKeys?: string[],
+  preservedKeys?: string[],
 ): ILoader<void, Record<string, any>> {
   switch (bucketType) {
     default:
@@ -103,6 +105,7 @@ export default function createBucketLoader(
         createFlatLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -115,6 +118,7 @@ export default function createBucketLoader(
         createFlatLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -127,6 +131,7 @@ export default function createBucketLoader(
         createFlatLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -139,6 +144,7 @@ export default function createBucketLoader(
         createFlatLoader(),
         createLockedKeysLoader(normalizeCsvPatterns(lockedKeys || [])),
         createIgnoredKeysLoader(normalizeCsvPatterns(ignoredKeys || [])),
+        createPreservedKeysLoader(normalizeCsvPatterns(preservedKeys || [])),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -150,6 +156,7 @@ export default function createBucketLoader(
         createHtmlLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -160,6 +167,7 @@ export default function createBucketLoader(
         createEjsLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -174,6 +182,7 @@ export default function createBucketLoader(
         createInjectLocaleLoader(options.injectLocale),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -187,6 +196,7 @@ export default function createBucketLoader(
         createInjectLocaleLoader(options.injectLocale),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -200,6 +210,7 @@ export default function createBucketLoader(
         createInjectLocaleLoader(options.injectLocale),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -211,6 +222,7 @@ export default function createBucketLoader(
         createMarkdownLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -223,6 +235,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -239,6 +252,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -250,6 +264,7 @@ export default function createBucketLoader(
         createMjmlLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -262,6 +277,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createVariableLoader({ type: "python" }),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
@@ -273,6 +289,7 @@ export default function createBucketLoader(
         createPropertiesLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -283,6 +300,7 @@ export default function createBucketLoader(
         createXcodeStringsLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -295,6 +313,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -309,6 +328,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(encodeKeys(lockedKeys || [])),
         createIgnoredKeysLoader(encodeKeys(ignoredKeys || [])),
+        createPreservedKeysLoader(encodeKeys(preservedKeys || [])),
         createSyncLoader(),
         createVariableLoader({ type: "ieee" }),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
@@ -324,6 +344,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(encodeKeys(lockedKeys || [])),
         createIgnoredKeysLoader(encodeKeys(ignoredKeys || [])),
+        createPreservedKeysLoader(encodeKeys(preservedKeys || [])),
         createSyncLoader(),
         createVariableLoader({ type: "ieee" }),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
@@ -338,6 +359,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -352,6 +374,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -366,6 +389,7 @@ export default function createBucketLoader(
         createFlatLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -378,6 +402,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -390,6 +415,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -400,6 +426,7 @@ export default function createBucketLoader(
         createSrtLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -411,6 +438,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
     case "vtt":
@@ -420,6 +448,7 @@ export default function createBucketLoader(
         createVttLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -433,6 +462,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
     case "vue-json":
@@ -445,6 +475,7 @@ export default function createBucketLoader(
         createEnsureKeyOrderLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
     case "typescript":
@@ -462,6 +493,7 @@ export default function createBucketLoader(
         createSyncLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
     case "twig":
@@ -471,6 +503,7 @@ export default function createBucketLoader(
         createTwigLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -481,6 +514,7 @@ export default function createBucketLoader(
         createTxtLoader(),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );
@@ -496,6 +530,7 @@ export default function createBucketLoader(
         createInjectLocaleLoader(options.injectLocale),
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
+        createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createUnlocalizableLoader(options.returnUnlocalizedKeys),
       );

--- a/packages/cli/src/cli/loaders/preserved-keys.spec.ts
+++ b/packages/cli/src/cli/loaders/preserved-keys.spec.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import createPreservedKeysLoader from "./preserved-keys";
+
+describe("preserved-keys loader", () => {
+  describe("pull", () => {
+    it("should remove preserved keys from data", async () => {
+      const loader = createPreservedKeysLoader(["preservedKey"]);
+      await loader.init();
+      loader.setDefaultLocale("en");
+
+      const result = await loader.pull("en", {
+        normalKey: "normal value",
+        preservedKey: "preserved value",
+        anotherKey: "another value",
+      });
+
+      expect(result).toEqual({
+        normalKey: "normal value",
+        anotherKey: "another value",
+      });
+    });
+
+    it("should handle wildcard patterns", async () => {
+      const loader = createPreservedKeysLoader(["legal.*"]);
+      await loader.init();
+      loader.setDefaultLocale("en");
+
+      const result = await loader.pull("en", {
+        normalKey: "normal value",
+        "legal.privacyUrl": "https://example.com/privacy",
+        "legal.termsUrl": "https://example.com/terms",
+        "support.email": "support@example.com",
+      });
+
+      expect(result).toEqual({
+        normalKey: "normal value",
+        "support.email": "support@example.com",
+      });
+    });
+
+    it("should handle nested keys with wildcard patterns", async () => {
+      const loader = createPreservedKeysLoader(["pages/*/title"]);
+      await loader.init();
+      loader.setDefaultLocale("en");
+
+      const result = await loader.pull("en", {
+        greeting: "hello",
+        "pages/0/title": "Title 0",
+        "pages/0/content": "Content 0",
+        "pages/foo/title": "Foo Title",
+        "pages/foo/content": "Foo Content",
+        "pages/bar/notitle": "No Title",
+        "pages/bar/content": "No Content",
+      });
+
+      expect(result).toEqual({
+        greeting: "hello",
+        "pages/0/content": "Content 0",
+        "pages/foo/content": "Foo Content",
+        "pages/bar/notitle": "No Title",
+        "pages/bar/content": "No Content",
+      });
+    });
+
+    it("should return all data when no preserved keys specified", async () => {
+      const loader = createPreservedKeysLoader([]);
+      await loader.init();
+      loader.setDefaultLocale("en");
+
+      const result = await loader.pull("en", {
+        normalKey: "normal value",
+        anotherKey: "another value",
+      });
+
+      expect(result).toEqual({
+        normalKey: "normal value",
+        anotherKey: "another value",
+      });
+    });
+  });
+
+  describe("push", () => {
+    it("should add preserved keys from source when missing in target", async () => {
+      const loader = createPreservedKeysLoader(["preservedKey"]);
+      await loader.init();
+      loader.setDefaultLocale("en");
+
+      // Pull from source (sets originalInput)
+      await loader.pull("en", {
+        normalKey: "normal value",
+        preservedKey: "source preserved value",
+      });
+
+      // Pull from target (target file does not have preservedKey)
+      await loader.pull("es", {
+        normalKey: "existing value",
+      });
+
+      // Push to target locale
+      const result = await loader.push(
+        "es",
+        { normalKey: "valor normal" }, // translated data
+      );
+
+      expect(result).toEqual({
+        normalKey: "valor normal",
+        preservedKey: "source preserved value", // Added from source
+      });
+    });
+
+    it("should keep existing target value for preserved keys", async () => {
+      const loader = createPreservedKeysLoader(["preservedKey"]);
+      await loader.init();
+      loader.setDefaultLocale("en");
+
+      // Pull from source (sets originalInput)
+      await loader.pull("en", {
+        normalKey: "normal value",
+        preservedKey: "source preserved value",
+      });
+
+      // Pull from target (target file has customized preservedKey)
+      await loader.pull("es", {
+        normalKey: "existing value",
+        preservedKey: "already customized value",
+      });
+
+      // Push to target locale
+      const result = await loader.push(
+        "es",
+        { normalKey: "valor normal" }, // translated data
+      );
+
+      expect(result).toEqual({
+        normalKey: "valor normal",
+        preservedKey: "already customized value", // Kept from target
+      });
+    });
+
+    it("should handle wildcard patterns for preserved keys", async () => {
+      const loader = createPreservedKeysLoader(["legal.*"]);
+      await loader.init();
+      loader.setDefaultLocale("en");
+
+      // Pull from source
+      await loader.pull("en", {
+        normalKey: "normal value",
+        "legal.privacyUrl": "https://example.com/privacy",
+        "legal.termsUrl": "https://example.com/terms",
+      });
+
+      // Pull from target (has one preserved key, missing another)
+      await loader.pull("es", {
+        normalKey: "existing",
+        "legal.privacyUrl": "https://es.example.com/privacidad",
+        // legal.termsUrl is missing
+      });
+
+      // Push to target locale
+      const result = await loader.push("es", { normalKey: "valor normal" });
+
+      expect(result).toEqual({
+        normalKey: "valor normal",
+        "legal.privacyUrl": "https://es.example.com/privacidad", // Kept from target
+        "legal.termsUrl": "https://example.com/terms", // Added from source
+      });
+    });
+
+    it("should handle nested keys with wildcard patterns for preserved keys", async () => {
+      const loader = createPreservedKeysLoader(["pages/*/title"]);
+      await loader.init();
+      loader.setDefaultLocale("en");
+
+      // Pull from source
+      await loader.pull("en", {
+        greeting: "hello",
+        "pages/0/title": "Title 0",
+        "pages/0/content": "Content 0",
+        "pages/foo/title": "Foo Title",
+        "pages/foo/content": "Foo Content",
+      });
+
+      // Pull from target (has one preserved key customized, another missing)
+      await loader.pull("es", {
+        greeting: "hola",
+        "pages/0/title": "Título Personalizado 0",
+        "pages/0/content": "Contenido 0",
+        // pages/foo/title is missing
+        "pages/foo/content": "Contenido Foo",
+      });
+
+      // Push to target locale
+      const result = await loader.push("es", {
+        greeting: "hola traducido",
+        "pages/0/content": "Contenido Nuevo 0",
+        "pages/foo/content": "Contenido Nuevo Foo",
+      });
+
+      expect(result).toEqual({
+        greeting: "hola traducido",
+        "pages/0/title": "Título Personalizado 0", // Kept from target
+        "pages/0/content": "Contenido Nuevo 0",
+        "pages/foo/title": "Foo Title", // Added from source (was missing)
+        "pages/foo/content": "Contenido Nuevo Foo",
+      });
+    });
+
+    it("should handle empty preserved keys array", async () => {
+      const loader = createPreservedKeysLoader([]);
+      await loader.init();
+      loader.setDefaultLocale("en");
+
+      await loader.pull("en", {
+        normalKey: "normal value",
+        anotherKey: "another value",
+      });
+
+      await loader.pull("es", {
+        normalKey: "existing",
+      });
+
+      const result = await loader.push("es", {
+        normalKey: "valor normal",
+        anotherKey: "otro valor",
+      });
+
+      expect(result).toEqual({
+        normalKey: "valor normal",
+        anotherKey: "otro valor",
+      });
+    });
+  });
+});

--- a/packages/cli/src/cli/loaders/preserved-keys.ts
+++ b/packages/cli/src/cli/loaders/preserved-keys.ts
@@ -1,0 +1,33 @@
+import { ILoader } from "./_types";
+import { createLoader } from "./_utils";
+import _ from "lodash";
+import { matchesKeyPattern } from "../utils/key-matching";
+
+export default function createPreservedKeysLoader(
+  preservedKeys: string[],
+): ILoader<Record<string, any>, Record<string, any>> {
+  return createLoader({
+    pull: async (_locale, data) => {
+      // Remove preserved keys from data (don't send them for translation)
+      return _.pickBy(
+        data,
+        (_value, key) => !matchesKeyPattern(key, preservedKeys),
+      );
+    },
+    push: async (_locale, data, originalInput, _originalLocale, pullInput) => {
+      // For preserved keys:
+      // - If exists in pullInput (target file), keep target value
+      // - If missing in pullInput, use source value from originalInput
+      const preservedSubObject = _.chain(originalInput)
+        .pickBy((_value, key) => matchesKeyPattern(key, preservedKeys))
+        .mapValues((sourceValue, key) => {
+          // Use existing target value if present, otherwise use source
+          const targetValue = pullInput?.[key];
+          return targetValue !== undefined ? targetValue : sourceValue;
+        })
+        .value();
+
+      return _.merge({}, data, preservedSubObject);
+    },
+  });
+}

--- a/packages/cli/src/cli/utils/buckets.ts
+++ b/packages/cli/src/cli/utils/buckets.ts
@@ -19,6 +19,7 @@ type BucketConfig = {
   lockedKeys?: string[];
   lockedPatterns?: string[];
   ignoredKeys?: string[];
+  preservedKeys?: string[];
 };
 
 export function getBuckets(i18nConfig: I18nConfig) {
@@ -49,6 +50,9 @@ export function getBuckets(i18nConfig: I18nConfig) {
       }
       if (bucketEntry.ignoredKeys) {
         config.ignoredKeys = bucketEntry.ignoredKeys;
+      }
+      if (bucketEntry.preservedKeys) {
+        config.preservedKeys = bucketEntry.preservedKeys;
       }
       return config;
     },
@@ -160,11 +164,11 @@ function expandPlaceholderedGlob(
       const sourcePathChunk = sourcePathChunks[localeSegmentIndex];
       const regexp = new RegExp(
         "(" +
-        pathPatternChunk
-          .replaceAll(".", "\\.")
-          .replaceAll("*", ".*")
-          .replace("[locale]", `)${sourceLocale}(`) +
-        ")",
+          pathPatternChunk
+            .replaceAll(".", "\\.")
+            .replaceAll("*", ".*")
+            .replace("[locale]", `)${sourceLocale}(`) +
+          ")",
       );
       const match = sourcePathChunk.match(regexp);
       if (match) {

--- a/packages/spec/src/config.ts
+++ b/packages/spec/src/config.ts
@@ -499,8 +499,7 @@ export const configV1_11Definition = extendConfigDefinition(
   {
     createSchema: (baseSchema) =>
       baseSchema.extend({
-        vNext: Z.string()
-          .optional(),
+        vNext: Z.string().optional(),
       }),
     createDefaultValue: (baseDefaultValue) => ({
       ...baseDefaultValue,
@@ -513,8 +512,39 @@ export const configV1_11Definition = extendConfigDefinition(
   },
 );
 
+// v1.11 -> v1.12
+// Changes: Add "preservedKeys" string array to bucket config
+export const bucketValueSchemaV1_12 = bucketValueSchemaV1_8.extend({
+  preservedKeys: Z.array(Z.string())
+    .optional()
+    .describe(
+      "Keys that are added to targets using source values as placeholders, but once present, are never overwritten by the CLI.",
+    ),
+});
+
+export const configV1_12Definition = extendConfigDefinition(
+  configV1_11Definition,
+  {
+    createSchema: (baseSchema) =>
+      baseSchema.extend({
+        buckets: Z.partialRecord(
+          bucketTypeSchema,
+          bucketValueSchemaV1_12,
+        ).default({}),
+      }),
+    createDefaultValue: (baseDefaultValue) => ({
+      ...baseDefaultValue,
+      version: "1.12",
+    }),
+    createUpgrader: (oldConfig) => ({
+      ...oldConfig,
+      version: "1.12",
+    }),
+  },
+);
+
 // exports
-export const LATEST_CONFIG_DEFINITION = configV1_11Definition;
+export const LATEST_CONFIG_DEFINITION = configV1_12Definition;
 
 export type I18nConfig = Z.infer<(typeof LATEST_CONFIG_DEFINITION)["schema"]>;
 


### PR DESCRIPTION
## Summary

Add preservedKeys bucket configuration option that allows keys to be initialized once from source and never overwritten by subsequent CLI runs.

## Changes

- Add preservedKeys to bucket schema (v1.12) in packages/spec/src/config.ts
- Implement preserved-keys.ts loader that excludes preserved keys from translation and restores
  existing target values
- Integrate preservedKeys across all bucket types in loader chain
- Add preservedKeys support to bucket config parsing in packages/cli/src/cli/utils/buckets.ts
- Update demo files with examples of preserved keys (both top-level and nested)

## Testing

**Business logic tests added:**

- [x] Keys matching patterns are excluded from pull (not sent for translation)
- [x] Existing target values are preserved on push
- [x] Missing target keys are initialized from source values
- [x] Empty preservedKeys array has no effect
- [x] Pattern matching works with prefix and glob patterns
- [x] All tests pass locally

## Visuals

 N/A - CLI feature, no UI changes.

## Checklist

- [x] Changeset added (if version bump needed)
- [x] Tests cover business logic (not just happy path)
- [x] No breaking changes (or documented below)

Closes  N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `preservedKeys` configuration option to buckets, enabling specified keys to be protected from overwriting in target files while remaining available for localization and customization.

* **Tests**
  * Added comprehensive test coverage for preserved keys functionality across pull and push workflows.

* **Chores**
  * Version bumped to 1.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->