### PR TITLE
feat(cli): add preservedKeys support to all commands

### DIFF
--- a/.changeset/wild-points-stop.md
+++ b/.changeset/wild-points-stop.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": minor
+---
+
+Add preservedKeys support to all CLI commands (purge, cleanup, status, lockfile, i18n) and create `show preserved-keys` command

--- a/packages/cli/src/cli/cmd/cleanup.ts
+++ b/packages/cli/src/cli/cmd/cleanup.ts
@@ -73,6 +73,7 @@ export default new Command()
             bucket.lockedKeys,
             bucket.lockedPatterns,
             bucket.ignoredKeys,
+            bucket.preservedKeys,
           );
           bucketLoader.setDefaultLocale(sourceLocale);
 

--- a/packages/cli/src/cli/cmd/i18n.ts
+++ b/packages/cli/src/cli/cmd/i18n.ts
@@ -226,6 +226,7 @@ export default new Command()
               bucket.lockedKeys,
               bucket.lockedPatterns,
               bucket.ignoredKeys,
+              bucket.preservedKeys,
             );
             bucketLoader.setDefaultLocale(sourceLocale);
             await bucketLoader.init();
@@ -265,6 +266,7 @@ export default new Command()
               bucket.lockedKeys,
               bucket.lockedPatterns,
               bucket.ignoredKeys,
+              bucket.preservedKeys,
             );
             bucketLoader.setDefaultLocale(sourceLocale);
             await bucketLoader.init();
@@ -377,6 +379,7 @@ export default new Command()
               bucket.lockedKeys,
               bucket.lockedPatterns,
               bucket.ignoredKeys,
+              bucket.preservedKeys,
             );
             bucketLoader.setDefaultLocale(sourceLocale);
             await bucketLoader.init();

--- a/packages/cli/src/cli/cmd/lockfile.ts
+++ b/packages/cli/src/cli/cmd/lockfile.ts
@@ -46,6 +46,7 @@ export default new Command()
             bucket.lockedKeys,
             bucket.lockedPatterns,
             bucket.ignoredKeys,
+            bucket.preservedKeys,
           );
           bucketLoader.setDefaultLocale(sourceLocale);
 

--- a/packages/cli/src/cli/cmd/purge.ts
+++ b/packages/cli/src/cli/cmd/purge.ts
@@ -105,6 +105,7 @@ export default new Command()
                 bucket.lockedKeys,
                 bucket.lockedPatterns,
                 bucket.ignoredKeys,
+                bucket.preservedKeys,
               );
               await bucketLoader.init();
               bucketLoader.setDefaultLocale(sourceLocale);

--- a/packages/cli/src/cli/cmd/show/_shared-key-command.ts
+++ b/packages/cli/src/cli/cmd/show/_shared-key-command.ts
@@ -5,7 +5,7 @@ import {
   formatDisplayValue,
 } from "../../utils/key-matching";
 
-export type KeyFilterType = "lockedKeys" | "ignoredKeys";
+export type KeyFilterType = "lockedKeys" | "ignoredKeys" | "preservedKeys";
 
 export interface KeyCommandOptions {
   bucket?: string;

--- a/packages/cli/src/cli/cmd/show/index.ts
+++ b/packages/cli/src/cli/cmd/show/index.ts
@@ -5,6 +5,7 @@ import localeCmd from "./locale";
 import filesCmd from "./files";
 import lockedKeysCmd from "./locked-keys";
 import ignoredKeysCmd from "./ignored-keys";
+import preservedKeysCmd from "./preserved-keys";
 
 export default new Command()
   .command("show")
@@ -14,4 +15,5 @@ export default new Command()
   .addCommand(localeCmd)
   .addCommand(filesCmd)
   .addCommand(lockedKeysCmd)
-  .addCommand(ignoredKeysCmd);
+  .addCommand(ignoredKeysCmd)
+  .addCommand(preservedKeysCmd);

--- a/packages/cli/src/cli/cmd/show/preserved-keys.ts
+++ b/packages/cli/src/cli/cmd/show/preserved-keys.ts
@@ -1,0 +1,38 @@
+import { Command } from "interactive-commander";
+import Ora from "ora";
+import { getConfig } from "../../utils/config";
+import { CLIError } from "../../utils/errors";
+import { getBuckets } from "../../utils/buckets";
+import { executeKeyCommand } from "./_shared-key-command";
+
+export default new Command()
+  .command("preserved-keys")
+  .description(
+    "Show which key-value pairs in source files match preservedKeys patterns",
+  )
+  .option("--bucket <name>", "Only show preserved keys for a specific bucket")
+  .helpOption("-h, --help", "Show help")
+  .action(async (options) => {
+    const ora = Ora();
+    try {
+      const i18nConfig = await getConfig();
+
+      if (!i18nConfig) {
+        throw new CLIError({
+          message:
+            "i18n.json not found. Please run `lingo.dev init` to initialize the project.",
+          docUrl: "i18nNotFound",
+        });
+      }
+
+      const buckets = getBuckets(i18nConfig);
+
+      await executeKeyCommand(i18nConfig, buckets, options, {
+        filterType: "preservedKeys",
+        displayName: "preserved",
+      });
+    } catch (error: any) {
+      ora.fail(error.message);
+      process.exit(1);
+    }
+  });

--- a/packages/cli/src/cli/cmd/status.ts
+++ b/packages/cli/src/cli/cmd/status.ts
@@ -203,6 +203,7 @@ export default new Command()
               bucket.lockedKeys,
               bucket.lockedPatterns,
               bucket.ignoredKeys,
+              bucket.preservedKeys,
             );
 
             bucketLoader.setDefaultLocale(sourceLocale);

--- a/packages/cli/src/cli/loaders/index.spec.ts
+++ b/packages/cli/src/cli/loaders/index.spec.ts
@@ -1027,6 +1027,7 @@ describe("bucket loaders", () => {
         undefined, // lockedKeys
         undefined, // lockedPatterns
         ["ignored.key", "nested/ignored"], // ignoredKeys
+        undefined, // preservedKeys
       );
 
       jsonLoader.setDefaultLocale("en");
@@ -1078,6 +1079,7 @@ describe("bucket loaders", () => {
         undefined, // lockedKeys
         undefined, // lockedPatterns
         ["wildcard_*"], // ignoredKeys with wildcard
+        undefined, // preservedKeys
       );
 
       jsonLoader.setDefaultLocale("en");
@@ -4266,13 +4268,14 @@ Línea 3`;
       // Locked keys should be filtered out (they get flattened and encoded)
       // After flat loader, keys become "hello%20world/stringUnit" and "%25lld%20unit_days/variations/plural"
       expect(dataForTranslation).not.toHaveProperty("hello%20world/stringUnit");
-      expect(dataForTranslation).not.toHaveProperty("%25lld%20unit_days/variations/plural");
+      expect(dataForTranslation).not.toHaveProperty(
+        "%25lld%20unit_days/variations/plural",
+      );
 
       // Non-locked keys should remain (flattened)
       expect(dataForTranslation).toHaveProperty("regular_key/stringUnit");
       expect(dataForTranslation["regular_key/stringUnit"]).toBe("Regular");
     });
-
   });
 
   describe("typescript bucket loader", () => {


### PR DESCRIPTION
## Summary

Add preservedKeys support to all CLI commands (purge, cleanup, status, lockfile, i18n) and create `show preserved-keys` command


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `show preserved-keys` command to display preserved keys in your configuration.
  * Extended core CLI commands (purge, cleanup, status, lockfile, and i18n) to support preservedKeys configuration for enhanced key management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->