### PR TITLE
fix(compiler): show error messages instead of showing `{}`

### DIFF
--- a/.changeset/every-experts-raise.md
+++ b/.changeset/every-experts-raise.md
@@ -1,0 +1,5 @@
+---
+"@lingo.dev/compiler": patch
+---
+
+Show error messages instead of showing `{}`


### PR DESCRIPTION
## Summary

The logging for lingo compiler hides errors:
```
[Lingo.dev] ⚠️  1 translation error(s) for uk
[Lingo.dev] ❌ Translation generation failed:

  - es: 1 translation(s) failed
  - ja: 1 translation(s) failed
  - de: 1 translation(s) failed
  - fr: 1 translation(s) failed
  - ms: 1 translation(s) failed
  - uk: 1 translation(s) failed
```

## Changes

- Now it actually shows you what the error is:
```
[Lingo.dev] ⚠️  1 translation error(s) for ko
[Lingo.dev] Translation failed: Error: LLM translation failed with openrouter: openrouter LLM translation to hi timed out after 60000ms
    at LingoTranslator.translateWithLLM (file:///Users/safe/repos/lingo.dev/packages/new-compiler/build/translators/lingo/translator.mjs:113:10)
    at async LingoTranslator.translateDictionary (file:///Users/safe/repos/lingo.dev/packages/new-compiler/build/translators/lingo/translator.mjs:43:28)
    at async LingoTranslator.translate (file:///Users/safe/repos/lingo.dev/packages/new-compiler/build/translators/lingo/translator.mjs:30:11)
    at async TranslationService.translate (file:///Users/safe/repos/lingo.dev/packages/new-compiler/build/translators/translation-service.mjs:101:29)
    at async TranslationServer.translateAll (file:///Users/safe/repos/lingo.dev/packages/new-compiler/build/translation-server/translation-server.mjs:240:18)
    at async file:///Users/safe/repos/lingo.dev/packages/new-compiler/build/plugin/build-translator.mjs:66:19
    at async Promise.all (index 13)
    at async processBuildTranslations (file:///Users/safe/repos/lingo.dev/packages/new-compiler/build/plugin/build-translator.mjs:80:3)
    at async Object.buildEnd (file:///Users/safe/repos/lingo.dev/packages/new-compiler/build/plugin/unplugin.mjs:122:6)
    at async Promise.all (index 1)
```

I was then able to increase the time out for LLM API calls to two minutes to get this to work. I don't think the current pattern of having a timeout for the entire API call for all the translations for a single language is a good idea though. Perhaps it could be broken down into different sections.

## Testing

Not business logic, but just error handling fixes. No tests required.

## Visuals

No user interface changed.

## Checklist

- [x] Changeset added (if version bump needed)
- [x] ~~Tests cover business logic (not just happy path)~~
- [x] No breaking changes (or documented below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error message display to show meaningful information instead of empty objects.
  * Improved error formatting to include error names, messages, stack traces, and chained errors for better diagnostics.

* **Chores**
  * Added a patch release note entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->