### PR TITLE
fix(cli): show correct status messages for vNext provider

### DIFF
--- a/.changeset/public-lies-check.md
+++ b/.changeset/public-lies-check.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+Fixed vNext provider showing incorrect status messages ("Skipping glossary", etc.) during setup

--- a/packages/cli/src/cli/cmd/run/setup.ts
+++ b/packages/cli/src/cli/cmd/run/setup.ts
@@ -59,7 +59,8 @@ export default async function setup(input: CmdRunContext) {
             );
           }
           task.title =
-            ctx.localizer.id === "Lingo.dev" || ctx.localizer.id === "Lingo.dev vNext"
+            ctx.localizer.id === "Lingo.dev" ||
+            ctx.localizer.id === "Lingo.dev vNext"
               ? `Using ${chalk.hex(colors.green)(ctx.localizer.id)} provider`
               : ctx.localizer.id === "pseudo"
                 ? `Using ${chalk.hex(colors.blue)("pseudo")} mode for testing`
@@ -69,7 +70,9 @@ export default async function setup(input: CmdRunContext) {
       {
         title: "Checking authentication",
         enabled: (ctx) =>
-          (ctx.localizer?.id === "Lingo.dev" || ctx.localizer?.id === "Lingo.dev vNext") && !ctx.flags.pseudo,
+          (ctx.localizer?.id === "Lingo.dev" ||
+            ctx.localizer?.id === "Lingo.dev vNext") &&
+          !ctx.flags.pseudo,
         task: async (ctx, task) => {
           const authStatus = await ctx.localizer!.checkAuth();
           if (!authStatus.authenticated) {
@@ -82,7 +85,9 @@ export default async function setup(input: CmdRunContext) {
       },
       {
         title: "Validating configuration",
-        enabled: (ctx) => ctx.localizer?.id !== "Lingo.dev" && ctx.localizer?.id !== "Lingo.dev vNext",
+        enabled: (ctx) =>
+          ctx.localizer?.id !== "Lingo.dev" &&
+          ctx.localizer?.id !== "Lingo.dev vNext",
         task: async (ctx, task) => {
           const validationStatus = await ctx.localizer!.validateSettings!();
           if (!validationStatus.valid) {
@@ -96,7 +101,9 @@ export default async function setup(input: CmdRunContext) {
       {
         title: "Initializing localization provider",
         async task(ctx, task) {
-          const isLingoDotDev = ctx.localizer!.id === "Lingo.dev";
+          const isLingoDotDev =
+            ctx.localizer!.id === "Lingo.dev" ||
+            ctx.localizer!.id === "Lingo.dev vNext";
           const isPseudo = ctx.localizer!.id === "pseudo";
 
           const subTasks = isLingoDotDev


### PR DESCRIPTION
## Summary

Fixed vNext provider showing incorrect status messages ("Skipping glossary", etc.) during setup

## Changes

- Fixed isLingoDotDev check to include "Lingo.dev vNext".   

## Testing

**Testing performed**

- [x] Verify vNext setup shows "Glossary enabled", "Brand voice enabled", "Translation memory
  connected", "Quality assurance enabled"
- [x] All tests pass locally

## Visuals

N/A

## Checklist

- [x] Changeset added (if version bump needed)
- [x] No breaking changes (or documented below)

Closes N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed erroneous status messages displayed during Lingo.dev vNext setup that incorrectly indicated features were being skipped

* **New Features**
  * Lingo.dev vNext provider now enables a complete set of localization features: brand voice management, translation memory integration, glossary support, and QA checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->