### PR TITLE
fix(compiler): Make pluralization model optional with lazy initialization

### DIFF
--- a/packages/new-compiler/src/translators/pluralization/types.ts
+++ b/packages/new-compiler/src/translators/pluralization/types.ts
@@ -23,9 +23,9 @@ export type PluralizationConfig = {
   /**
    * LLM provider for pluralization detection
    * Format: "provider:model" (e.g., "groq:llama3-8b-8192")
-   * If omitted in user config, the compiler can infer it from translation models.
+   * Required when enabled: true, optional when enabled: false
    */
-  model: string;
+  model?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary
This PR fixes the issue where the pluralization model was always required and initialized, even when pluralization was disabled or not needed.

## Changes

### 1. types.ts
- Made `model` optional in `PluralizationConfig`
- Updated JSDoc to clarify model is only required when enabled

### 2. service.ts  
- Added runtime validation: throws helpful error if enabled=true but no model
- Implemented lazy model initialization with `getOrCreateLanguageModel()`
- Model is now only created when `generateBatch()` is called (not in constructor)
- Added better error messages for configuration issues

## Benefits
- Better DX: Users don't need to provide model config when pluralization is disabled
- Performance: No unnecessary model initialization  
- Resource efficiency: No API key validation when pluralization isn't used
- Backward compatible: Existing configs with model provided still work

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Verified error message when enabled=true without model
- [ ] Verified lazy initialization works correctly

Fixes #1981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pluralization feature now uses lazy initialization of language models, improving application startup performance.
  * Language model configuration is now optional when pluralization is disabled, providing more flexible setup options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->