### PR TITLE
fix(cli): guard against empty translations in PO loader

### DIFF
--- a/.changeset/fix-po-loader-crash.md
+++ b/.changeset/fix-po-loader-crash.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+Fix crash in PO loader when current section has no translations

--- a/packages/cli/src/cli/loaders/po/index.ts
+++ b/packages/cli/src/cli/loaders/po/index.ts
@@ -67,8 +67,14 @@ export function createPoDataLoader(
           // If the section is empty, try to find it in the current sections
           const currentSection = currentSections.find((cs) => {
             const csPo = gettextParser.po.parse(cs);
+            if (Object.keys(csPo.translations).length === 0) {
+              return false;
+            }
             const csContextKey = _.keys(csPo.translations)[0];
             const csEntries = csPo.translations[csContextKey];
+            if (!csEntries) {
+              return false;
+            }
             const csMsgid = Object.keys(csEntries).find(
               (key) => csEntries[key].msgid,
             );


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot convert undefined or null to object` crash in PO loader's `push` method
- Add guards to skip sections with empty/missing translations inside `currentSections.find()` callback, matching the existing guard pattern in the outer `.map()`

## Test plan
- [ ] Verify PO files with obsolete-only sections no longer crash during push
- [ ] Verify normal PO file processing is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the PO loader when processing sections without translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->