### PR TITLE
feat(cli): add localizableKeys config option to bypass untranslatable…

### DIFF
--- a/.changeset/lazy-wings-joke.md
+++ b/.changeset/lazy-wings-joke.md
@@ -1,0 +1,6 @@
+---
+"@lingo.dev/_spec": minor
+"lingo.dev": minor
+---
+
+Add localizableKeys bucket config option to force-translate values that would otherwise be skipped by the untranslatable filter (e.g. pure numbers, URLs, ISO dates).

--- a/packages/cli/src/cli/cmd/cleanup.ts
+++ b/packages/cli/src/cli/cmd/cleanup.ts
@@ -74,6 +74,7 @@ export default new Command()
             bucket.lockedPatterns,
             bucket.ignoredKeys,
             bucket.preservedKeys,
+            bucket.localizableKeys,
           );
           bucketLoader.setDefaultLocale(sourceLocale);
 

--- a/packages/cli/src/cli/cmd/i18n.ts
+++ b/packages/cli/src/cli/cmd/i18n.ts
@@ -227,6 +227,7 @@ export default new Command()
               bucket.lockedPatterns,
               bucket.ignoredKeys,
               bucket.preservedKeys,
+              bucket.localizableKeys,
             );
             bucketLoader.setDefaultLocale(sourceLocale);
             await bucketLoader.init();
@@ -267,6 +268,7 @@ export default new Command()
               bucket.lockedPatterns,
               bucket.ignoredKeys,
               bucket.preservedKeys,
+              bucket.localizableKeys,
             );
             bucketLoader.setDefaultLocale(sourceLocale);
             await bucketLoader.init();
@@ -380,6 +382,7 @@ export default new Command()
               bucket.lockedPatterns,
               bucket.ignoredKeys,
               bucket.preservedKeys,
+              bucket.localizableKeys,
             );
             bucketLoader.setDefaultLocale(sourceLocale);
             await bucketLoader.init();

--- a/packages/cli/src/cli/cmd/lockfile.ts
+++ b/packages/cli/src/cli/cmd/lockfile.ts
@@ -47,6 +47,7 @@ export default new Command()
             bucket.lockedPatterns,
             bucket.ignoredKeys,
             bucket.preservedKeys,
+            bucket.localizableKeys,
           );
           bucketLoader.setDefaultLocale(sourceLocale);
 

--- a/packages/cli/src/cli/cmd/purge.ts
+++ b/packages/cli/src/cli/cmd/purge.ts
@@ -106,6 +106,7 @@ export default new Command()
                 bucket.lockedPatterns,
                 bucket.ignoredKeys,
                 bucket.preservedKeys,
+                bucket.localizableKeys,
               );
               await bucketLoader.init();
               bucketLoader.setDefaultLocale(sourceLocale);

--- a/packages/cli/src/cli/cmd/run/_types.ts
+++ b/packages/cli/src/cli/cmd/run/_types.ts
@@ -33,6 +33,7 @@ export type CmdRunTask = {
   lockedPatterns: string[];
   ignoredKeys: string[];
   preservedKeys: string[];
+  localizableKeys: string[];
   onlyKeys: string[];
   formatter?: "prettier" | "biome";
 };

--- a/packages/cli/src/cli/cmd/run/execute.ts
+++ b/packages/cli/src/cli/cmd/run/execute.ts
@@ -164,6 +164,7 @@ function createLoaderForTask(assignedTask: CmdRunTask) {
     assignedTask.lockedPatterns,
     assignedTask.ignoredKeys,
     assignedTask.preservedKeys,
+    assignedTask.localizableKeys,
   );
   bucketLoader.setDefaultLocale(assignedTask.sourceLocale);
 

--- a/packages/cli/src/cli/cmd/run/frozen.ts
+++ b/packages/cli/src/cli/cmd/run/frozen.ts
@@ -65,6 +65,7 @@ export default async function frozen(input: CmdRunContext) {
                   bucket.lockedPatterns,
                   bucket.ignoredKeys,
                   bucket.preservedKeys,
+                  bucket.localizableKeys,
                 );
                 loader.setDefaultLocale(resolvedSourceLocale);
                 await loader.init();
@@ -105,6 +106,7 @@ export default async function frozen(input: CmdRunContext) {
                 bucket.lockedPatterns,
                 bucket.ignoredKeys,
                 bucket.preservedKeys,
+                bucket.localizableKeys,
               );
               loader.setDefaultLocale(resolvedSourceLocale);
               await loader.init();

--- a/packages/cli/src/cli/cmd/run/plan.ts
+++ b/packages/cli/src/cli/cmd/run/plan.ts
@@ -134,6 +134,7 @@ export default async function plan(
                   lockedPatterns: bucket.lockedPatterns || [],
                   ignoredKeys: bucket.ignoredKeys || [],
                   preservedKeys: bucket.preservedKeys || [],
+                  localizableKeys: bucket.localizableKeys || [],
                   onlyKeys: input.flags.key || [],
                   formatter: input.config!.formatter,
                 });

--- a/packages/cli/src/cli/cmd/status.ts
+++ b/packages/cli/src/cli/cmd/status.ts
@@ -204,6 +204,7 @@ export default new Command()
               bucket.lockedPatterns,
               bucket.ignoredKeys,
               bucket.preservedKeys,
+              bucket.localizableKeys,
             );
 
             bucketLoader.setDefaultLocale(sourceLocale);

--- a/packages/cli/src/cli/loaders/index.ts
+++ b/packages/cli/src/cli/loaders/index.ts
@@ -92,6 +92,7 @@ export default function createBucketLoader(
   lockedPatterns?: string[],
   ignoredKeys?: string[],
   preservedKeys?: string[],
+  localizableKeys?: string[],
 ): ILoader<void, Record<string, any>> {
   switch (bucketType) {
     default:
@@ -107,7 +108,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "android":
       return composeLoaders(
@@ -120,7 +124,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "csv":
       return composeLoaders(
@@ -133,7 +140,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "csv-per-locale":
       return composeLoaders(
@@ -146,7 +156,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(normalizeCsvPatterns(ignoredKeys || [])),
         createPreservedKeysLoader(normalizeCsvPatterns(preservedKeys || [])),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          normalizeCsvPatterns(localizableKeys || []),
+        ),
       );
     case "html":
       return composeLoaders(
@@ -158,7 +171,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "ejs":
       return composeLoaders(
@@ -169,7 +185,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "json":
       return composeLoaders(
@@ -184,7 +203,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "json5":
       return composeLoaders(
@@ -198,7 +220,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "jsonc":
       return composeLoaders(
@@ -212,7 +237,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "markdown":
       return composeLoaders(
@@ -224,7 +252,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "markdoc":
       return composeLoaders(
@@ -237,7 +268,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "mdx":
       return composeLoaders(
@@ -254,7 +288,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "mjml":
       return composeLoaders(
@@ -266,7 +303,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "po":
       return composeLoaders(
@@ -280,7 +320,10 @@ export default function createBucketLoader(
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
         createVariableLoader({ type: "python" }),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "properties":
       return composeLoaders(
@@ -291,7 +334,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "xcode-strings":
       return composeLoaders(
@@ -302,7 +348,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "xcode-stringsdict":
       return composeLoaders(
@@ -315,7 +364,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "xcode-xcstrings":
       return composeLoaders(
@@ -331,7 +383,10 @@ export default function createBucketLoader(
         createPreservedKeysLoader(encodeKeys(preservedKeys || [])),
         createSyncLoader(),
         createVariableLoader({ type: "ieee" }),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          encodeKeys(localizableKeys || []),
+        ),
       );
     case "xcode-xcstrings-v2":
       return composeLoaders(
@@ -347,7 +402,10 @@ export default function createBucketLoader(
         createPreservedKeysLoader(encodeKeys(preservedKeys || [])),
         createSyncLoader(),
         createVariableLoader({ type: "ieee" }),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          encodeKeys(localizableKeys || []),
+        ),
       );
     case "yaml":
       return composeLoaders(
@@ -361,7 +419,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "yaml-root-key":
       return composeLoaders(
@@ -376,7 +437,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "flutter":
       return composeLoaders(
@@ -391,7 +455,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "xliff":
       return composeLoaders(
@@ -404,7 +471,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "xml":
       return composeLoaders(
@@ -417,7 +487,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "srt":
       return composeLoaders(
@@ -428,7 +501,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "dato":
       return composeLoaders(
@@ -439,7 +515,10 @@ export default function createBucketLoader(
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "vtt":
       return composeLoaders(
@@ -450,7 +529,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "php":
       return composeLoaders(
@@ -463,7 +545,10 @@ export default function createBucketLoader(
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "vue-json":
       return composeLoaders(
@@ -476,7 +561,10 @@ export default function createBucketLoader(
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "typescript":
       return composeLoaders(
@@ -494,7 +582,10 @@ export default function createBucketLoader(
         createLockedKeysLoader(lockedKeys || []),
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "twig":
       return composeLoaders(
@@ -505,7 +596,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "txt":
       return composeLoaders(
@@ -516,7 +610,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
     case "json-dictionary":
       return composeLoaders(
@@ -532,7 +629,10 @@ export default function createBucketLoader(
         createIgnoredKeysLoader(ignoredKeys || []),
         createPreservedKeysLoader(preservedKeys || []),
         createSyncLoader(),
-        createUnlocalizableLoader(options.returnUnlocalizedKeys),
+        createUnlocalizableLoader(
+          options.returnUnlocalizedKeys,
+          localizableKeys,
+        ),
       );
   }
 }

--- a/packages/cli/src/cli/loaders/unlocalizable.spec.ts
+++ b/packages/cli/src/cli/loaders/unlocalizable.spec.ts
@@ -46,6 +46,109 @@ describe("unlocalizable loader", () => {
     expect(result).toEqual({ ...data, ...pushData });
   });
 
+  describe("localizableKeys bypass", () => {
+    it("should keep a numeric string key if it is in localizableKeys", async () => {
+      const loader = createUnlocalizableLoader(false, ["num"]);
+      loader.setDefaultLocale("en");
+      const result = await loader.pull("en", data);
+
+      expect(result).toEqual({
+        foo: "bar",
+        num: 1,
+        numStr: "1.0",
+        boolStr: "false",
+        bar: "foo",
+      });
+    });
+
+    it("should keep multiple bypassed keys", async () => {
+      const loader = createUnlocalizableLoader(false, ["num", "url"]);
+      loader.setDefaultLocale("en");
+      const result = await loader.pull("en", data);
+
+      expect(result).toEqual({
+        foo: "bar",
+        num: 1,
+        numStr: "1.0",
+        boolStr: "false",
+        bar: "foo",
+        url: "https://example.com",
+      });
+    });
+
+    it("should restore bypassed keys on push", async () => {
+      const pushData = {
+        foo: "bar-es",
+        bar: "foo-es",
+        num: 112,
+        numStr: "2.0",
+        boolStr: "true",
+        url: "https://example.es",
+      };
+
+      const loader = createUnlocalizableLoader(false, ["num", "url"]);
+      loader.setDefaultLocale("en");
+      await loader.pull("en", data);
+      const result = await loader.push("es", pushData);
+
+      expect(result).toEqual({ ...data, ...pushData });
+    });
+
+    it("should support nested key paths", async () => {
+      const nestedData = {
+        foo: "bar",
+        "config/count": 42,
+        "config/url": "https://example.com",
+      };
+
+      const loader = createUnlocalizableLoader(false, ["config/count"]);
+      loader.setDefaultLocale("en");
+      const result = await loader.pull("en", nestedData);
+
+      expect(result).toEqual({
+        foo: "bar",
+        "config/count": 42,
+      });
+    });
+
+    it("should support prefix matching", async () => {
+      const nestedData = {
+        foo: "bar",
+        "config/count": 42,
+        "config/url": "https://example.com",
+      };
+
+      const loader = createUnlocalizableLoader(false, ["config"]);
+      loader.setDefaultLocale("en");
+      const result = await loader.pull("en", nestedData);
+
+      expect(result).toEqual({
+        foo: "bar",
+        "config/count": 42,
+        "config/url": "https://example.com",
+      });
+    });
+
+    it("should support glob patterns", async () => {
+      const nestedData = {
+        foo: "bar",
+        "config/count": 42,
+        "settings/count": 100,
+        "config/url": "https://example.com",
+      };
+
+      const loader = createUnlocalizableLoader(false, ["*/count"]);
+      loader.setDefaultLocale("en");
+      const result = await loader.pull("en", nestedData);
+
+      expect(result).toEqual({
+        foo: "bar",
+        "config/count": 42,
+        "settings/count": 100,
+      });
+    });
+  });
+
   describe("return unlocalizable keys", () => {
     describe.each([true, false])("%s", (returnUnlocalizedKeys) => {
       it("should return unlocalizable keys on pull", async () => {

--- a/packages/cli/src/cli/utils/buckets.ts
+++ b/packages/cli/src/cli/utils/buckets.ts
@@ -20,6 +20,7 @@ type BucketConfig = {
   lockedPatterns?: string[];
   ignoredKeys?: string[];
   preservedKeys?: string[];
+  localizableKeys?: string[];
 };
 
 export function getBuckets(i18nConfig: I18nConfig) {
@@ -53,6 +54,9 @@ export function getBuckets(i18nConfig: I18nConfig) {
       }
       if (bucketEntry.preservedKeys) {
         config.preservedKeys = bucketEntry.preservedKeys;
+      }
+      if (bucketEntry.localizableKeys) {
+        config.localizableKeys = bucketEntry.localizableKeys;
       }
       return config;
     },

--- a/packages/spec/src/config.ts
+++ b/packages/spec/src/config.ts
@@ -543,8 +543,39 @@ export const configV1_12Definition = extendConfigDefinition(
   },
 );
 
+// v1.12 -> v1.13
+// Changes: Add "localizableKeys" string array to bucket config
+export const bucketValueSchemaV1_13 = bucketValueSchemaV1_12.extend({
+  localizableKeys: Z.array(Z.string())
+    .optional()
+    .describe(
+      "Keys whose values should always be sent for translation, even if they would normally be skipped as untranslatable (e.g. pure numbers, URLs, dates). Use this to force-translate values that have custom glossary rules.",
+    ),
+});
+
+export const configV1_13Definition = extendConfigDefinition(
+  configV1_12Definition,
+  {
+    createSchema: (baseSchema) =>
+      baseSchema.extend({
+        buckets: Z.partialRecord(
+          bucketTypeSchema,
+          bucketValueSchemaV1_13,
+        ).default({}),
+      }),
+    createDefaultValue: (baseDefaultValue) => ({
+      ...baseDefaultValue,
+      version: "1.13",
+    }),
+    createUpgrader: (oldConfig) => ({
+      ...oldConfig,
+      version: "1.13",
+    }),
+  },
+);
+
 // exports
-export const LATEST_CONFIG_DEFINITION = configV1_12Definition;
+export const LATEST_CONFIG_DEFINITION = configV1_13Definition;
 
 export type I18nConfig = Z.infer<(typeof LATEST_CONFIG_DEFINITION)["schema"]>;
 


### PR DESCRIPTION
# Summary

Add `localizableKeys` bucket config option to force‑translate values that would otherwise be auto‑skipped by the untranslatable filter (e.g., pure numbers, URLs, ISO dates).

## Changes

- Added config schema **v1.13** with optional `localizableKeys: string[]` on bucket config.
- Wired `localizableKeys` through all **33 bucket types** in the loader pipeline and all **10 `createBucketLoader`** call sites.
- Used `matchesKeyPattern` for matching — supports **exact**, **prefix**, and **glob** patterns (consistent with `lockedKeys`, `ignoredKeys`, `preservedKeys`).
- Applied `encodeKeys` for `xcode-xcstrings` variants and `normalizeCsvPatterns` for `csv-per-locale` (consistent with other key configs).

## Testing

Business logic tests added:

- Exact key match - numeric value bypasses unlocalizable filter.
- Multiple bypassed keys - several keys kept in a single pull.
- Push round‑trip - bypassed keys correctly restored on push.
- Nested key paths - `"config/count"` matches flattened nested objects.
- Prefix matching - `"config"` matches all keys under `config/`.
- Glob patterns - `"*/count"` matches `count` at any level.

## Visuals

N/A - no UI changes.

## Checklist

- [X] Changeset added.
- [X] Tests cover business logic (not just happy path).
- [X] No breaking changes - `localizableKeys` is optional, existing configs unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `localizableKeys` bucket configuration option to force translation of specific values that would normally be excluded (such as numbers, URLs, and dates). This enhancement ensures custom translation rules can be applied to these previously skipped values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->