### PR TITLE
fix(cli): handle rebase abort crash in CI pull-request flow

### DIFF
--- a/.changeset/fix-ci-rebase-abort-crash.md
+++ b/.changeset/fix-ci-rebase-abort-crash.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+fix(cli): handle rebase abort gracefully when no rebase is in progress

--- a/packages/cli/src/cli/cmd/ci/flows/pull-request.ts
+++ b/packages/cli/src/cli/cmd/ci/flows/pull-request.ts
@@ -156,9 +156,13 @@ export class PullRequestFlow extends InBranchFlow {
     } catch (error) {
       this.ora.warn("Rebase failed, falling back to alternative sync method");
 
-      this.ora.start("Aborting failed rebase");
-      execSync("git rebase --abort", { stdio: "inherit" });
-      this.ora.succeed("Aborted failed rebase");
+      try {
+        this.ora.start("Aborting failed rebase");
+        execSync("git rebase --abort", { stdio: "inherit" });
+        this.ora.succeed("Aborted failed rebase");
+      } catch {
+        this.ora.warn("No rebase in progress to abort");
+      }
 
       this.ora.start(
         `Resetting to ${this.platformKit.platformConfig.baseBranchName}`,


### PR DESCRIPTION
## Summary
- Wrapped `git rebase --abort` in a try/catch in the CI pull-request flow so it doesn't crash when no rebase is actually in progress
- Previously, if the rebase failure was resolved before the abort step (or never started), the unhandled error would crash the entire flow

## Test plan
- [ ] Run CI pull-request flow where rebase fails and verify it falls back gracefully
- [ ] Run CI pull-request flow where rebase succeeds and verify normal behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the CI pull request flow that occurred when rebasing failed and the CLI attempted to abort a non-existent rebase. The workflow now handles this scenario gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->