### PR TITLE
fix(new-compiler): use dynamic import for lmdb to avoid CJS transform errors

### DIFF
--- a/.changeset/hungry-taxes-mate.md
+++ b/.changeset/hungry-taxes-mate.md
@@ -1,0 +1,5 @@
+---
+"@lingo.dev/compiler": patch
+---
+
+Fixed SyntaxError caused by bundlers/require hooks transforming lmdb's CJS bundle


### PR DESCRIPTION
## Summary

Use dynamic import for lmdb to fix SyntaxError: 'super' keyword unexpected here caused by bundlers/require hooks transforming lmdb's CJS bundle.

## Changes

- Changed openDatabaseConnection to async and load lmdb via await import("lmdb") at call time instead of top-level static import

## Testing

**Business logic tests added:**

- [x] Reproduced the error with Next.js 15.1.11 — confirmed fix resolves it
- [x] Existing metadata unit tests pass
- [x] All tests pass locally

## Visuals

 N/A - no UI changes.

## Checklist

- [x] Changeset added (if version bump needed)
- [x] No breaking changes (or documented below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Resolved a SyntaxError that occurred when using bundlers or require hooks with the compiler package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->