### PR TITLE
feat(sdk): add vNext API support to LingoDotDevEngine

### DIFF
--- a/.changeset/bold-bushes-relax.md
+++ b/.changeset/bold-bushes-relax.md
@@ -1,0 +1,6 @@
+---
+"lingo.dev": patch
+"@lingo.dev/_sdk": patch
+---
+
+Add vNext API support to LingoDotDevEngine. When engineId is provided, the engine routes requests to the vNext API. Refactor vNext localizer to use LingoDotDevEngine from SDK instead of custom inline implementation

--- a/packages/cli/src/cli/localizer/lingodotdev-vnext.ts
+++ b/packages/cli/src/cli/localizer/lingodotdev-vnext.ts
@@ -2,185 +2,8 @@ import dedent from "dedent";
 import { ILocalizer, LocalizerData } from "./_types";
 import chalk from "chalk";
 import { colors } from "../constants";
+import { LingoDotDevEngine } from "@lingo.dev/_sdk";
 import { getSettings } from "../utils/settings";
-import { createId } from "@paralleldrive/cuid2";
-
-/**
- * Creates a custom engine for Lingo.dev vNext that sends requests to:
- * https://api.lingo.dev/process/<processId>/localize
- */
-function createVNextEngine(config: {
-  apiKey: string;
-  apiUrl: string;
-  processId: string;
-  sessionId: string;
-  triggerType: "cli" | "ci";
-}) {
-  const endpoint = `${config.apiUrl}/process/${config.processId}/localize`;
-
-  return {
-    async localizeChunk(
-      sourceLocale: string | null,
-      targetLocale: string,
-      payload: {
-        data: Record<string, any>;
-        reference?: Record<string, Record<string, any>>;
-        hints?: Record<string, string[]>;
-      },
-      fast: boolean,
-      filePath?: string,
-      signal?: AbortSignal,
-    ): Promise<Record<string, string>> {
-      const res = await fetch(endpoint, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json; charset=utf-8",
-          "X-API-Key": config.apiKey,
-        },
-        body: JSON.stringify(
-          {
-            params: { fast },
-            sourceLocale,
-            targetLocale,
-            data: payload.data,
-            reference: payload.reference,
-            hints: payload.hints,
-            sessionId: config.sessionId,
-            triggerType: config.triggerType,
-            metadata: filePath ? { filePath } : undefined,
-          },
-          null,
-          2,
-        ),
-        signal,
-      });
-
-      if (!res.ok) {
-        if (res.status >= 500 && res.status < 600) {
-          const errorText = await res.text();
-          throw new Error(
-            `Server error (${res.status}): ${res.statusText}. ${errorText}. This may be due to temporary service issues.`,
-          );
-        } else if (res.status === 400) {
-          throw new Error(`Invalid request: ${res.statusText}`);
-        } else {
-          const errorText = await res.text();
-          throw new Error(errorText);
-        }
-      }
-
-      const jsonResponse = await res.json();
-
-      if (!jsonResponse.data && jsonResponse.error) {
-        throw new Error(jsonResponse.error);
-      }
-
-      return jsonResponse.data || {};
-    },
-
-    async whoami(
-      signal?: AbortSignal,
-    ): Promise<{ email: string; id: string } | null> {
-      // vNext uses a simple response for whoami
-      return { email: "vnext-user", id: config.processId };
-    },
-
-    async localizeObject(
-      obj: Record<string, any>,
-      params: {
-        sourceLocale: string | null;
-        targetLocale: string;
-        fast?: boolean;
-        reference?: Record<string, Record<string, any>>;
-        hints?: Record<string, string[]>;
-        filePath?: string;
-      },
-      progressCallback?: (
-        progress: number,
-        sourceChunk: Record<string, string>,
-        processedChunk: Record<string, string>,
-      ) => void,
-      signal?: AbortSignal,
-    ): Promise<Record<string, string>> {
-      const chunkedPayload = extractPayloadChunks(obj);
-      const processedPayloadChunks: Record<string, string>[] = [];
-
-      for (let i = 0; i < chunkedPayload.length; i++) {
-        const chunk = chunkedPayload[i];
-        const percentageCompleted = Math.round(
-          ((i + 1) / chunkedPayload.length) * 100,
-        );
-
-        const processedPayloadChunk = await this.localizeChunk(
-          params.sourceLocale,
-          params.targetLocale,
-          { data: chunk, reference: params.reference, hints: params.hints },
-          params.fast || false,
-          params.filePath,
-          signal,
-        );
-
-        if (progressCallback) {
-          progressCallback(percentageCompleted, chunk, processedPayloadChunk);
-        }
-
-        processedPayloadChunks.push(processedPayloadChunk);
-      }
-
-      return Object.assign({}, ...processedPayloadChunks);
-    },
-  };
-}
-
-/**
- * Helper functions for chunking payloads
- */
-function extractPayloadChunks(
-  payload: Record<string, string>,
-  batchSize: number = 25,
-  idealBatchItemSize: number = 250,
-): Record<string, string>[] {
-  const result: Record<string, string>[] = [];
-  let currentChunk: Record<string, string> = {};
-  let currentChunkItemCount = 0;
-
-  const payloadEntries = Object.entries(payload);
-  for (let i = 0; i < payloadEntries.length; i++) {
-    const [key, value] = payloadEntries[i];
-    currentChunk[key] = value;
-    currentChunkItemCount++;
-
-    const currentChunkSize = countWordsInRecord(currentChunk);
-    if (
-      currentChunkSize > idealBatchItemSize ||
-      currentChunkItemCount >= batchSize ||
-      i === payloadEntries.length - 1
-    ) {
-      result.push(currentChunk);
-      currentChunk = {};
-      currentChunkItemCount = 0;
-    }
-  }
-
-  return result;
-}
-
-function countWordsInRecord(
-  payload: any | Record<string, any> | Array<any>,
-): number {
-  if (Array.isArray(payload)) {
-    return payload.reduce((acc, item) => acc + countWordsInRecord(item), 0);
-  } else if (typeof payload === "object" && payload !== null) {
-    return Object.values(payload).reduce(
-      (acc: number, item) => acc + countWordsInRecord(item),
-      0,
-    );
-  } else if (typeof payload === "string") {
-    return payload.trim().split(/\s+/).filter(Boolean).length;
-  } else {
-    return 0;
-  }
-}
 
 export default function createLingoDotDevVNextLocalizer(
   processId: string,
@@ -207,15 +30,12 @@ export default function createLingoDotDevVNextLocalizer(
   // Use LINGO_API_URL from environment or default to api.lingo.dev
   const apiUrl = process.env.LINGO_API_URL || "https://api.lingo.dev";
 
-  const sessionId = createId();
   const triggerType = process.env.CI ? "ci" : "cli";
 
-  const engine = createVNextEngine({
+  const engine = new LingoDotDevEngine({
     apiKey,
     apiUrl,
-    processId,
-    sessionId,
-    triggerType,
+    engineId: processId,
   });
 
   return {
@@ -250,6 +70,7 @@ export default function createLingoDotDevVNextLocalizer(
           },
           hints: input.hints,
           filePath: input.filePath,
+          triggerType,
         },
         onProgress,
       );

--- a/packages/sdk/src/index.spec.ts
+++ b/packages/sdk/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("./utils/observability");
 
@@ -150,6 +150,187 @@ describe("ReplexicaEngine", () => {
       );
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("localizeChat", () => {
+    it("should flatten chat texts and preserve speaker names", async () => {
+      const engine = new LingoDotDevEngine({ apiKey: "test" });
+      const mockLocalizeRaw = vi.spyOn(engine as any, "_localizeRaw");
+      mockLocalizeRaw.mockImplementation(async (obj: any) => {
+        return Object.fromEntries(
+          Object.entries(obj).map(([key, value]) => [key, `ES:${value}`]),
+        );
+      });
+
+      const input = [
+        { name: "Alice", text: "Hello! How are you?" },
+        { name: "Bob", text: "I'm doing great, thanks!" },
+      ];
+
+      const result = await engine.localizeChat(input, {
+        sourceLocale: "en",
+        targetLocale: "es",
+      });
+
+      // Verify only texts are sent, keyed by index
+      expect(mockLocalizeRaw).toHaveBeenCalledWith(
+        {
+          chat_0: "Hello! How are you?",
+          chat_1: "I'm doing great, thanks!",
+        },
+        { sourceLocale: "en", targetLocale: "es" },
+        undefined,
+        undefined,
+      );
+
+      // Verify names are preserved and texts are translated
+      expect(result).toEqual([
+        { name: "Alice", text: "ES:Hello! How are you?" },
+        { name: "Bob", text: "ES:I'm doing great, thanks!" },
+      ]);
+    });
+  });
+
+  describe("LingoDotDevEngine with engineId (vNext)", () => {
+    let mockFetch: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockFetch = vi.fn();
+      global.fetch = mockFetch as any;
+    });
+
+    it("should use vNext endpoint and X-API-Key header", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { greeting: "Hola" } }),
+      });
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-vnext-key",
+        engineId: "eng_123",
+      });
+
+      await engine.localizeObject(
+        { greeting: "Hello" },
+        { sourceLocale: "en", targetLocale: "es" },
+      );
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toMatch(/\/process\/eng_123\/localize$/);
+      expect(options.headers["X-API-Key"]).toBe("test-vnext-key");
+      expect(options.headers["Authorization"]).toBeUndefined();
+    });
+
+    it("should send flat locale fields (not nested)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { greeting: "Hola" } }),
+      });
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        engineId: "eng_123",
+      });
+
+      await engine.localizeObject(
+        { greeting: "Hello" },
+        { sourceLocale: "en", targetLocale: "es" },
+      );
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.sourceLocale).toBe("en");
+      expect(body.targetLocale).toBe("es");
+      expect(body.locale).toBeUndefined();
+    });
+
+    it("should include sessionId and triggerType in request body", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { greeting: "Hola" } }),
+      });
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        engineId: "eng_123",
+      });
+
+      await engine.localizeObject(
+        { greeting: "Hello" },
+        { sourceLocale: "en", targetLocale: "es", triggerType: "ci" },
+      );
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.sessionId).toBeDefined();
+      expect(body.triggerType).toBe("ci");
+    });
+
+    it("should generate a consistent sessionId across multiple requests", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { a: "Hola", b: "Adios" } }),
+      });
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        engineId: "eng_123",
+      });
+
+      await engine.localizeObject(
+        { a: "Hello" },
+        { sourceLocale: "en", targetLocale: "es" },
+      );
+      await engine.localizeObject(
+        { b: "Goodbye" },
+        { sourceLocale: "en", targetLocale: "es" },
+      );
+
+      const sessionId1 = JSON.parse(mockFetch.mock.calls[0][1].body).sessionId;
+      const sessionId2 = JSON.parse(mockFetch.mock.calls[1][1].body).sessionId;
+      expect(sessionId1).toBe(sessionId2);
+    });
+
+    it("should include filePath in metadata when provided", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { greeting: "Hola" } }),
+      });
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        engineId: "eng_123",
+      });
+
+      await engine.localizeObject(
+        { greeting: "Hello" },
+        {
+          sourceLocale: "en",
+          targetLocale: "es",
+          filePath: "src/messages.json",
+        },
+      );
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.metadata).toEqual({ filePath: "src/messages.json" });
+    });
+
+    it("should use /process/recognize endpoint for recognizeLocale", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ locale: "fr" }),
+      });
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        engineId: "eng_123",
+      });
+
+      const result = await engine.recognizeLocale("Bonjour le monde");
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toMatch(/\/process\/recognize$/);
+      expect(options.headers["X-API-Key"]).toBe("test-key");
+      expect(result).toBe("fr");
     });
   });
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,6 +9,7 @@ const engineParamsSchema = Z.object({
   apiUrl: Z.string().url().default("https://engine.lingo.dev"),
   batchSize: Z.number().int().gt(0).lte(250).default(25),
   idealBatchItemSize: Z.number().int().gt(0).lte(2500).default(250),
+  engineId: Z.string().optional(),
 }).passthrough();
 
 const payloadSchema = Z.record(Z.string(), Z.any());
@@ -21,6 +22,8 @@ const localizationParamsSchema = Z.object({
   fast: Z.boolean().optional(),
   reference: referenceSchema.optional(),
   hints: hintsSchema.optional(),
+  filePath: Z.string().optional(),
+  triggerType: Z.enum(["cli", "ci"]).optional(),
 });
 
 /**
@@ -31,12 +34,34 @@ const localizationParamsSchema = Z.object({
 export class LingoDotDevEngine {
   protected config: Z.infer<typeof engineParamsSchema>;
 
+  private readonly sessionId = createId();
+
+  private get isVNext(): boolean {
+    return !!this.config.engineId;
+  }
+
+  private get headers(): Record<string, string> {
+    return this.isVNext
+      ? {
+          "Content-Type": "application/json; charset=utf-8",
+          "X-API-Key": this.config.apiKey,
+        }
+      : {
+          "Content-Type": "application/json; charset=utf-8",
+          Authorization: `Bearer ${this.config.apiKey}`,
+        };
+  }
+
   /**
    * Create a new LingoDotDevEngine instance
    * @param config - Configuration options for the Engine
    */
   constructor(config: Partial<Z.infer<typeof engineParamsSchema>>) {
-    this.config = engineParamsSchema.parse(config);
+    const parsed = engineParamsSchema.parse(config);
+    if (!config.apiUrl && parsed.engineId) {
+      parsed.apiUrl = "https://api.lingo.dev";
+    }
+    this.config = parsed;
   }
 
   /**
@@ -77,6 +102,8 @@ export class LingoDotDevEngine {
         { data: chunk, reference: params.reference, hints: params.hints },
         workflowId,
         params.fast || false,
+        params.filePath,
+        params.triggerType,
         signal,
       );
 
@@ -97,6 +124,8 @@ export class LingoDotDevEngine {
    * @param payload - Payload containing the chunk to be localized
    * @param workflowId - Workflow ID for tracking
    * @param fast - Whether to use fast mode
+   * @param filePath - Optional file path for metadata
+   * @param triggerType - Optional trigger type for vNext requests
    * @param signal - Optional AbortSignal to cancel the operation
    * @returns Localized chunk
    */
@@ -110,16 +139,27 @@ export class LingoDotDevEngine {
     },
     workflowId: string,
     fast: boolean,
+    filePath?: string,
+    triggerType?: "cli" | "ci",
     signal?: AbortSignal,
   ): Promise<Record<string, string>> {
-    const res = await fetch(`${this.config.apiUrl}/i18n`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        Authorization: `Bearer ${this.config.apiKey}`,
-      },
-      body: JSON.stringify(
-        {
+    const url = this.isVNext
+      ? `${this.config.apiUrl}/process/${this.config.engineId}/localize`
+      : `${this.config.apiUrl}/i18n`;
+
+    const body = this.isVNext
+      ? {
+          params: { fast },
+          sourceLocale,
+          targetLocale,
+          data: payload.data,
+          reference: payload.reference,
+          hints: payload.hints,
+          sessionId: this.sessionId,
+          triggerType,
+          metadata: filePath ? { filePath } : undefined,
+        }
+      : {
           params: { workflowId, fast },
           locale: {
             source: sourceLocale,
@@ -128,10 +168,12 @@ export class LingoDotDevEngine {
           data: payload.data,
           reference: payload.reference,
           hints: payload.hints,
-        },
-        null,
-        2,
-      ),
+        };
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: this.headers,
+      body: JSON.stringify(body, null, 2),
       signal,
     });
 
@@ -455,8 +497,16 @@ export class LingoDotDevEngine {
       trackProps,
     );
     try {
+      const mapped = chat.reduce(
+        (acc, msg, i) => {
+          acc[`chat_${i}`] = msg.text;
+          return acc;
+        },
+        {} as Record<string, string>,
+      );
+
       const localized = await this._localizeRaw(
-        { chat },
+        mapped,
         params,
         progressCallback,
         signal,
@@ -689,12 +739,13 @@ export class LingoDotDevEngine {
       trackProps,
     );
     try {
-      const response = await fetch(`${this.config.apiUrl}/recognize`, {
+      const url = this.isVNext
+        ? `${this.config.apiUrl}/process/recognize`
+        : `${this.config.apiUrl}/recognize`;
+
+      const response = await fetch(url, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json; charset=utf-8",
-          Authorization: `Bearer ${this.config.apiKey}`,
-        },
+        headers: this.headers,
         body: JSON.stringify({ text }),
         signal,
       });
@@ -733,6 +784,10 @@ export class LingoDotDevEngine {
   async whoami(
     signal?: AbortSignal,
   ): Promise<{ email: string; id: string } | null> {
+    if (this.isVNext) {
+      return { email: "vnext-user", id: this.config.engineId! };
+    }
+
     try {
       const res = await fetch(`${this.config.apiUrl}/whoami`, {
         method: "POST",


### PR DESCRIPTION
## Summary

  Add vNext API support to the JavaScript SDK's `LingoDotDevEngine`, allowing it to route requests to the vNext API when `engineId` is provided.

## Changes

  - Add `engineId` as an optional config parameter to `LingoDotDevEngine` in the SDK
  - When `engineId` is set, the engine uses vNext endpoints `/process/{engineId}/localize`, `/process/recognize`, `X-API-Key` auth header, and defaults apiUrl to `https://api.lingo.dev`
  - Add `filePath` and `triggerType` as optional localization params to support vNext metadata
  - Add per-instance `sessionId` for vNext request grouping
  - Fix localizeChat to use flat key-value map (chat_0, chat_1) instead of nested object
  - Refactor CLI's `lingodotdev-vnext.ts` to use the SDK's `LingoDotDevEngine` instead of a custom inline implementation

## Testing

**Business logic tests added:**

  - [x] vNext uses correct endpoint (/process/{engineId}/localize) and X-API-Key header
  - [x] vNext sends flat sourceLocale/targetLocale fields (not nested locale object)
  - [x] sessionId is consistent across multiple requests from the same engine instance
  - [x] triggerType is passed through when provided
  - [x] filePath is included in metadata when provided
  - [x] recognizeLocale uses /process/recognize endpoint for vNext
  - [x] localizeChat flattens and reconstructs chat messages correctly
  - [x] All tests pass locally 

## Visuals

N/A — no UI changes.

## Checklist

- [x] Changeset added (if version bump needed)
- [x] Tests cover business logic (not just happy path)
- [ ] No breaking changes (or documented below)

Closes N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vNext API support with engineId-based routing for improved localization workflows.
  * Chat localization now available, with speaker names preserved during translation.
  * Enhanced metadata support including file path tracking in localization requests.

* **Refactor**
  * Streamlined vNext localizer integration with the SDK engine for better code consistency.

* **Tests**
  * Expanded test coverage for vNext API flows and session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->