### PR TITLE
fix(sdk): remove unused workflowId parameter from localizeChunk

### DIFF
--- a/.changeset/little-nails-notice.md
+++ b/.changeset/little-nails-notice.md
@@ -1,0 +1,5 @@
+---
+"@lingo.dev/_sdk": patch
+---
+
+Remove unused workflowId parameter from internal localizeChunk method

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -76,7 +76,6 @@ export class LingoDotDevEngine {
     const chunkedPayload = this.extractPayloadChunks(finalPayload);
     const processedPayloadChunks: Record<string, string>[] = [];
 
-    const workflowId = createId();
     for (let i = 0; i < chunkedPayload.length; i++) {
       const chunk = chunkedPayload[i];
       const percentageCompleted = Math.round(
@@ -87,7 +86,6 @@ export class LingoDotDevEngine {
         finalParams.sourceLocale,
         finalParams.targetLocale,
         { data: chunk, reference: params.reference, hints: params.hints },
-        workflowId,
         params.fast || false,
         params.filePath,
         params.triggerType,
@@ -109,7 +107,6 @@ export class LingoDotDevEngine {
    * @param sourceLocale - Source locale
    * @param targetLocale - Target locale
    * @param payload - Payload containing the chunk to be localized
-   * @param workflowId - Workflow ID for tracking
    * @param fast - Whether to use fast mode
    * @param filePath - Optional file path for metadata
    * @param triggerType - Optional trigger type
@@ -124,7 +121,6 @@ export class LingoDotDevEngine {
       reference?: Z.infer<typeof referenceSchema>;
       hints?: Z.infer<typeof hintsSchema>;
     },
-    workflowId: string,
     fast: boolean,
     filePath?: string,
     triggerType?: "cli" | "ci",


### PR DESCRIPTION
## Summary                                                                               
                                                                                           
  Remove dead `workflowId` parameter from internal SDK method `localizeChunk`.             
                                                                                           
  ## Changes                                                                               
                                                                                           
  - Removed unused `workflowId` parameter from private `localizeChunk` method
  - Removed `workflowId` generation via `createId()` in `_localizeRaw`
  - Cleaned up corresponding JSDoc

  ## Testing

  **Business logic tests added:**

  - [x] All existing 24 SDK tests pass locally

  ## Visuals

  > N/A — no UI changes.

  ## Checklist

  - [x] Changeset added (if version bump needed)
  - [x] Tests cover business logic (not just happy path)
  - [x] No breaking changes (or documented below)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal parameters from the chunk processing pipeline and updated related documentation for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->