### PR TITLE
fix(new-compiler): disable noSync for shared metadata LMDB writes

### DIFF
--- a/packages/new-compiler/src/metadata/fixtures/save-metadata-worker.ts
+++ b/packages/new-compiler/src/metadata/fixtures/save-metadata-worker.ts
@@ -4,7 +4,29 @@ import { generateTranslationHash } from "../../utils/hash";
 const dbPath = process.argv[2];
 const workerId = Number(process.argv[3]);
 const iterations = Number(process.argv[4]);
-const noSync = process.argv[5] === "true";
+const noSyncArg = process.argv[5];
+
+if (!dbPath) {
+  console.error("Missing dbPath argument");
+  process.exit(2);
+}
+
+if (Number.isNaN(workerId)) {
+  console.error("Invalid workerId argument");
+  process.exit(2);
+}
+
+if (Number.isNaN(iterations)) {
+  console.error("Invalid iterations argument");
+  process.exit(2);
+}
+
+if (noSyncArg !== "true" && noSyncArg !== "false") {
+  console.error("Invalid noSync argument");
+  process.exit(2);
+}
+
+const noSync = noSyncArg === "true";
 
 function createEntry(i: number) {
   const sourceText = `worker-${workerId}-entry-${i}`;

--- a/packages/new-compiler/src/metadata/manager.test.ts
+++ b/packages/new-compiler/src/metadata/manager.test.ts
@@ -70,6 +70,13 @@ async function runSaveMetadataWorker(
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString();
     });
+    child.on("error", (error) => {
+      reject(
+        new Error(
+          `worker ${workerId} failed to spawn: ${error.message}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      );
+    });
 
     child.on("exit", (code, signal) => {
       if (code === 0) {

--- a/packages/new-compiler/src/metadata/manager.ts
+++ b/packages/new-compiler/src/metadata/manager.ts
@@ -7,6 +7,8 @@ import { logger } from "../utils/logger";
 
 const METADATA_DIR_DEV = "metadata-dev";
 const METADATA_DIR_BUILD = "metadata-build";
+// Metadata writes require synchronized commits because bundlers can fan out
+// multiple worker processes against the same LMDB path.
 const METADATA_DB_NO_SYNC = false;
 
 /**
@@ -18,11 +20,14 @@ const METADATA_DB_NO_SYNC = false;
  * lmdb is loaded via dynamic import() to prevent bundlers and require hooks
  * from transforming its CJS bundle, which contains syntax they can't handle.
  */
-async function openDatabaseConnection(dbPath: string, noSync: boolean): Promise<RootDatabase> {
+async function openDatabaseConnection(
+  dbPath: string,
+  _noSync: boolean,
+): Promise<RootDatabase> {
   try {
     fs.mkdirSync(dbPath, { recursive: true });
     const { open } = await import("lmdb");
-    const effectiveNoSync = noSync ? METADATA_DB_NO_SYNC : false;
+    const effectiveNoSync = METADATA_DB_NO_SYNC;
     return open({
       path: dbPath,
       compression: true,


### PR DESCRIPTION
## Linked issue
- Root-cause investigation and original report: #2047

## Summary
- force synchronized LMDB commits for compiler metadata writes
- add a multi-process regression test for `saveMetadata(..., true)`

## Root cause
`@lingo.dev/compiler` writes build metadata from multiple bundler worker processes into the same LMDB path.

Before this patch, `saveMetadata()` forwarded `noSync=true` during production builds. In local stress testing on macOS, that combination caused two failure modes:

1. worker processes aborting with exit code `134`
2. successful exits with missing metadata entries

The failures reproduced without Next.js or app code involved, using only concurrent child processes calling `saveMetadata()` against the same database path.

The same stress test passed when:
- each worker wrote to its own LMDB path, or
- the shared metadata database used `noSync=false`

That points to `noSync=true` on a shared metadata LMDB as the unsafe part of the current implementation.

## Validation
- `pnpm --filter @lingo.dev/compiler exec vitest --run src/metadata/manager.test.ts`
- repeated 24-process stress runs writing 2400 total entries with `saveMetadata(..., true)` now finish at `2400/2400`

## Notes
I also saw unrelated existing workspace issues when running the full package test/typecheck suite from a fresh clone:
- missing `lingo.dev/spec` / `lingo.dev/sdk` resolution in `tsc`
- existing vitest failures in `src/react/server-only/index.test.tsx` and `src/translation-server/translation-server.test.ts`

Those were present outside this patch, so this PR keeps the scope limited to the metadata regression.

Closes #2047


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-process concurrent metadata handling with synchronized data writes.

* **Tests**
  * Introduced concurrent access testing to verify metadata integrity across multiple parallel processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->