### PR TITLE
chore: remove stale TODO comment

### DIFF
--- a/.changeset/remove-stale-todo.md
+++ b/.changeset/remove-stale-todo.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+chore: remove stale TODO comment

--- a/packages/cli/src/cli/loaders/typescript/index.spec.ts
+++ b/packages/cli/src/cli/loaders/typescript/index.spec.ts
@@ -342,5 +342,4 @@ Incluye también "prueba"\`,
     );
   });
 
-  // TODO
 });


### PR DESCRIPTION
## Summary
- Remove empty `// TODO` comment from typescript loader spec
- Includes a changeset to trigger a release (unblocks publish of pending 0.133.10 changes)

## Test plan
- [ ] CI passes
- [ ] After merge, release workflow creates a release PR bumping to 0.133.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed stale TODO comment from the CLI test suite to improve code organization and reduce technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->