### PR TITLE
fix(cli): support mixed-case source locales on Windows

### DIFF
--- a/.changeset/dull-eyes-live.md
+++ b/.changeset/dull-eyes-live.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+Fix Windows: translations now generate for mixed-case source locales (e.g. `en-US`). The placeholder reinsertion regex in `buckets.ts` was case-sensitive while paths were lowercased on Windows, so `[locale]` was lost from the matched pattern and only the source file was rewritten.

--- a/packages/cli/src/cli/utils/buckets.spec.ts
+++ b/packages/cli/src/cli/utils/buckets.spec.ts
@@ -184,6 +184,49 @@ describe("getBuckets", () => {
     warnSpy.mockRestore();
   });
 
+  it("should reinsert [locale] on Windows when source locale has uppercase letters", () => {
+    // On Windows, `normalizePath` lowercases the path returned from glob to
+    // compensate for case-insensitive filesystems. The placeholder
+    // reinsertion regex must therefore match case-insensitively or the
+    // `[locale]` token is lost — see the customer report where translations
+    // were never generated on Windows for sources like `en-US`.
+    const originalPlatform = Object.getOwnPropertyDescriptor(
+      process,
+      "platform",
+    );
+    Object.defineProperty(process, "platform", {
+      value: "win32",
+      configurable: true,
+    });
+    try {
+      mockGlobSync(["src/assets/locales/en-US/common.json"]);
+      const i18nConfig = {
+        $schema: "https://lingo.dev/schema/i18n.json",
+        version: 0,
+        locale: { source: "en-US", targets: ["de-DE", "pl-PL", "es-ES"] },
+        buckets: {
+          json: { include: ["src/assets/locales/[locale]/*.json"] },
+        },
+      };
+      const buckets = getBuckets(i18nConfig as any);
+      expect(normalizePaths(buckets)).toEqual([
+        {
+          type: "json",
+          paths: [
+            {
+              pathPattern: "src/assets/locales/[locale]/common.json",
+              delimiter: null,
+            },
+          ],
+        },
+      ]);
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, "platform", originalPlatform);
+      }
+    }
+  });
+
   it("should return bucket with multiple locale placeholders", () => {
     mockGlobSync(
       ["src/i18n/en/en.json"],

--- a/packages/cli/src/cli/utils/buckets.ts
+++ b/packages/cli/src/cli/utils/buckets.ts
@@ -185,6 +185,10 @@ function expandPlaceholderedGlob(
       // Find the position of the "[locale]" placeholder within the segment
       const pathPatternChunk = pathPatternChunks[localeSegmentIndex];
       const sourcePathChunk = sourcePathChunks[localeSegmentIndex];
+      // Case-insensitive: on Windows, `normalizePath` lowercases the matched
+      // path while `sourceLocale` retains its original casing (e.g. `en-US`),
+      // so a case-sensitive match here would fail and the `[locale]`
+      // placeholder would never be reinserted.
       const regexp = new RegExp(
         "(" +
           pathPatternChunk
@@ -192,6 +196,7 @@ function expandPlaceholderedGlob(
             .replaceAll("*", ".*")
             .replace("[locale]", `)${sourceLocale}(`) +
           ")",
+        "i",
       );
       const match = sourcePathChunk.match(regexp);
       if (match) {


### PR DESCRIPTION
## Summary

Fix Windows CLI: translations are now generated for mixed-case source locales (e.g. `en-US`) — previously only the source file was rewritten and no target locales were produced.

## Changes

- Make the `[locale]` placeholder reinsertion regex in `packages/cli/src/cli/utils/buckets.ts` case-insensitive so it still matches after `normalizePath` lowercases the path on Windows.
- Add a regression test that stubs `process.platform = "win32"` and asserts the placeholder survives for a mixed-case source locale (`en-US`).

## Testing

**Business logic tests added:**

- [x] Regression test in `buckets.spec.ts`: Windows + `en-US` source → `[locale]` is correctly reinserted into the returned `pathPattern`
- [x] Verified the test fails without the fix
- [x] All tests pass locally
- [x] End-to-end verified on Windows

## Visuals

N/A

## Checklist

- [x] Changeset added (if version bump needed)
- [x] Tests cover business logic (not just happy path)
- [x] No breaking changes (or documented below)

Closes N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows-specific issue preventing translation generation for source locales with mixed-case identifiers (e.g., `en-US`).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lingodotdev/lingo.dev/pull/2082)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->