### PR TITLE
fix: persist checksums on no-op runs to keep --frozen valid

### DIFF
--- a/.changeset/frozen-skip-saves-checksums.md
+++ b/.changeset/frozen-skip-saves-checksums.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+Fix `--frozen` falsely reporting "Source file has been updated" after a no-op `run`. When `lingo.dev run` finds nothing to translate (source matches target), it now persists source checksums to `i18n.lock` so a subsequent `--frozen` run has a baseline to validate against.

--- a/packages/cli/src/cli/cmd/run/execute.ts
+++ b/packages/cli/src/cli/cmd/run/execute.ts
@@ -239,6 +239,17 @@ function createWorkerTask(args: {
               await fileIoLimiter(async () => {
                 // re-push in case some of the unlocalizable / meta data changed
                 await bucketLoader.push(assignedTask.targetLocale, targetData);
+
+                // Persist checksums even when no work was needed, so a
+                // subsequent `--frozen` run has a baseline to validate against.
+                // Without this, an "everything already translated" run leaves
+                // i18n.lock without an entry for this pattern, and --frozen
+                // then reports the source as changed.
+                const checksums =
+                  await deltaProcessor.createChecksums(sourceData);
+                if (!args.ctx.flags.targetLocale?.length) {
+                  await deltaProcessor.saveChecksums(checksums);
+                }
               });
               return {
                 status: "skipped",


### PR DESCRIPTION
## Summary

`lingo.dev run --frozen` was failing with `Source file has been updated` even when nothing had changed and a normal `run` succeeded cleanly.

Root cause: when a run has nothing to translate (source already in sync with target), the worker exits via the `skipped` branch in `packages/cli/src/cli/cmd/run/execute.ts` **without** persisting source checksums to `i18n.lock`. The next `--frozen` validation then loads an empty checksum map for that pattern and treats every key as changed.

This PR mirrors the existing `saveChecksums` logic from the success branch into the skip branch, so a no-op run still leaves a valid baseline in `i18n.lock`. The `if (!args.ctx.flags.targetLocale?.length)` gate is preserved to keep the same "don't write the lockfile on a partial `--target-locale` run" semantics.

## Test plan

- [x] Reproduced the bug locally on `main`: empty `checksums: {}` + in-sync source/target → `run` skips, `run --frozen` fails with the reported error.
- [x] After the fix: `run` now writes checksums for the pattern → subsequent `run --frozen` exits cleanly.
- [x] `pnpm test` in `packages/cli` — 877/877 pass.

## Notes

A related concurrent-write race in `saveChecksums` (read-modify-write on the whole lockfile without a global serializer) is pre-existing and out of scope for this PR. Worth a follow-up to wrap `saveChecksums` in the already-available `ioLimiter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `--frozen` flag incorrectly reporting "Source file has been updated" when no translation work was required. Subsequent frozen validations now work correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lingodotdev/lingo.dev/pull/2091?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->