### PR TITLE
fix(cli): make 'lingo.dev lockfile' additively populate missing sections

### DIFF
--- a/.changeset/lockfile-merge-missing-sections.md
+++ b/.changeset/lockfile-merge-missing-sections.md
@@ -1,5 +1,5 @@
 ---
-"lingo.dev": patch
+"lingo.dev": minor
 ---
 
 Change the default behavior of `lingo.dev lockfile` so it fills in missing `i18n.lock` sections additively instead of bailing out. Without `--force`, sections that already contain checksums are left untouched (preserving the divergence signal that `--frozen` relies on), and any pathPattern whose section is missing or empty is populated from the current source. `--force` still rebuilds the entire lock as before.

--- a/.changeset/lockfile-merge-missing-sections.md
+++ b/.changeset/lockfile-merge-missing-sections.md
@@ -1,0 +1,9 @@
+---
+"lingo.dev": patch
+---
+
+Change the default behavior of `lingo.dev lockfile` so it fills in missing `i18n.lock` sections additively instead of bailing out. Without `--force`, sections that already contain checksums are left untouched (preserving the divergence signal that `--frozen` relies on), and any pathPattern whose section is missing or empty is populated from the current source. `--force` still rebuilds the entire lock as before.
+
+Update the `--frozen` validation error to point users at the recovery command: messages now read "Run `lingo.dev lockfile` to refresh i18n.lock, or run without --frozen."
+
+Together these surface a fix for the false-positive `--frozen` failures that PR #2091 did not cover (new files under `**` globs, new buckets, prior `--target-locale` runs that don't write checksums, and pre-existing empty lock sections).

--- a/packages/cli/src/cli/cmd/lockfile.spec.ts
+++ b/packages/cli/src/cli/cmd/lockfile.spec.ts
@@ -190,4 +190,17 @@ describe("cmd lockfile (merge-default)", () => {
     expect(lockAfterSecond.checksums[cKey]).toBeDefined();
     expect(lockAfterSecond.checksums[cKey].greeting).toBe(MD5("hello-c"));
   });
+
+  it("exits gracefully when i18n.json is missing (does not crash)", async () => {
+    // Intentionally no i18n.json. A stale lock alone simulates the regression
+    // path from the reviewer: lock exists, config absent. Old code printed a
+    // warning; the merge-default code must not crash via getBuckets(null).
+    writeLock({ version: 1, checksums: {} });
+
+    await expect(runLockfile()).resolves.not.toThrow();
+
+    // Lock file is untouched.
+    const lock = readLock();
+    expect(lock.checksums).toEqual({});
+  });
 });

--- a/packages/cli/src/cli/cmd/lockfile.spec.ts
+++ b/packages/cli/src/cli/cmd/lockfile.spec.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import YAML from "yaml";
+import { MD5 } from "object-hash";
+
+// The repo's vitest setup (tests/mock-storage.ts) globally mocks fs/promises
+// to read/write from an in-memory store. These tests need real disk I/O so the
+// JSON bucket loader can `fs.readFile` source files written by the test.
+vi.unmock("fs/promises");
+
+let lockfileCmd: any;
+
+async function freshCmd() {
+  vi.resetModules();
+  // Dynamic import so each test gets a fresh Commander instance.
+  const mod = await import("./lockfile");
+  lockfileCmd = mod.default;
+}
+
+async function runLockfile(args: string[] = []) {
+  await lockfileCmd.parseAsync(["node", "lockfile", ...args]);
+}
+
+function writeJson(filePath: string, content: any) {
+  const dir = path.dirname(filePath);
+  if (dir !== "." && !fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(filePath, JSON.stringify(content, null, 2));
+}
+
+function readLock(): { version: number; checksums: Record<string, Record<string, string>> } {
+  const raw = fs.readFileSync("i18n.lock", "utf-8");
+  return YAML.parse(raw);
+}
+
+function writeLock(data: any) {
+  fs.writeFileSync("i18n.lock", YAML.stringify(data));
+}
+
+function makeConfig(buckets: any) {
+  return {
+    $schema: "https://lingo.dev/schema/i18n.json",
+    version: 0,
+    locale: { source: "en", targets: ["es"] },
+    buckets,
+  };
+}
+
+describe("cmd lockfile (merge-default)", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lingo-lockfile-cmd-"));
+    process.chdir(tmpDir);
+    await freshCmd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("fills in a missing section while leaving an existing section byte-identical", async () => {
+    writeJson("i18n.json", makeConfig({
+      json: {
+        include: ["src/a/[locale].json", "src/b/[locale].json"],
+      },
+    }));
+    writeJson("src/a/en.json", { greeting: "hello-a" });
+    writeJson("src/a/es.json", { greeting: "hola-a" });
+    writeJson("src/b/en.json", { greeting: "hello-b" });
+    writeJson("src/b/es.json", { greeting: "hola-b" });
+
+    // Pre-populate lock with only section A.
+    const sectionAKey = MD5("src/a/[locale].json");
+    const sectionAExisting = { greeting: "preexisting-hash-A" };
+    writeLock({
+      version: 1,
+      checksums: { [sectionAKey]: sectionAExisting },
+    });
+
+    await runLockfile();
+
+    const lock = readLock();
+    const sectionBKey = MD5("src/b/[locale].json");
+
+    expect(lock.checksums[sectionAKey]).toEqual(sectionAExisting);
+    expect(lock.checksums[sectionBKey]).toBeDefined();
+    expect(lock.checksums[sectionBKey].greeting).toBe(MD5("hello-b"));
+  });
+
+  it("populates sections when the lock exists but checksums map is empty", async () => {
+    writeJson("i18n.json", makeConfig({
+      json: { include: ["src/[locale].json"] },
+    }));
+    writeJson("src/en.json", { greeting: "hello" });
+    writeJson("src/es.json", { greeting: "hola" });
+
+    writeLock({ version: 1, checksums: {} });
+
+    await runLockfile();
+
+    const lock = readLock();
+    const key = MD5("src/[locale].json");
+    expect(lock.checksums[key]).toBeDefined();
+    expect(lock.checksums[key].greeting).toBe(MD5("hello"));
+  });
+
+  it("does NOT overwrite a section whose source value changed (preserves the divergence signal for --frozen)", async () => {
+    writeJson("i18n.json", makeConfig({
+      json: { include: ["src/[locale].json"] },
+    }));
+    writeJson("src/en.json", { greeting: "hello-new" });
+    writeJson("src/es.json", { greeting: "hola-stale" });
+
+    const key = MD5("src/[locale].json");
+    const stale = { greeting: MD5("hello-old") };
+    writeLock({ version: 1, checksums: { [key]: stale } });
+
+    await runLockfile();
+
+    const lock = readLock();
+    // Section is byte-equivalent (parsed) to before: stale checksum preserved.
+    expect(lock.checksums[key]).toEqual(stale);
+    // Sanity: stale entry is genuinely diverged from current source, so a
+    // subsequent --frozen run would still throw "Source file has been updated"
+    // (validated by frozen.ts:127-131 via checksum mismatch).
+    expect(lock.checksums[key].greeting).not.toBe(MD5("hello-new"));
+  });
+
+  it("--force rebuilds existing sections (regression guard)", async () => {
+    writeJson("i18n.json", makeConfig({
+      json: { include: ["src/[locale].json"] },
+    }));
+    writeJson("src/en.json", { greeting: "hello-new" });
+    writeJson("src/es.json", { greeting: "hola" });
+
+    const key = MD5("src/[locale].json");
+    const stale = { greeting: MD5("hello-old") };
+    writeLock({ version: 1, checksums: { [key]: stale } });
+
+    await runLockfile(["--force"]);
+
+    const lock = readLock();
+    expect(lock.checksums[key].greeting).toBe(MD5("hello-new"));
+  });
+
+  it("adds only new pathPatterns under a ** recursive glob across two runs", async () => {
+    writeJson("i18n.json", makeConfig({
+      json: { include: ["src/[locale]/**/*.json"] },
+    }));
+
+    writeJson("src/en/feature-a.json", { greeting: "hello-a" });
+    writeJson("src/es/feature-a.json", { greeting: "hola-a" });
+    writeJson("src/en/feature-b.json", { greeting: "hello-b" });
+    writeJson("src/es/feature-b.json", { greeting: "hola-b" });
+
+    await runLockfile();
+
+    const lockAfterFirst = readLock();
+    const featureAPattern = "src/[locale]/feature-a.json";
+    const featureBPattern = "src/[locale]/feature-b.json";
+    const featureCPattern = "src/[locale]/feature-c.json";
+    const aKey = MD5(featureAPattern);
+    const bKey = MD5(featureBPattern);
+    const cKey = MD5(featureCPattern);
+
+    expect(lockAfterFirst.checksums[aKey]).toBeDefined();
+    expect(lockAfterFirst.checksums[bKey]).toBeDefined();
+    expect(lockAfterFirst.checksums[cKey]).toBeUndefined();
+
+    const sectionABefore = lockAfterFirst.checksums[aKey];
+    const sectionBBefore = lockAfterFirst.checksums[bKey];
+
+    // Add a third file.
+    writeJson("src/en/feature-c.json", { greeting: "hello-c" });
+    writeJson("src/es/feature-c.json", { greeting: "hola-c" });
+
+    await freshCmd();
+    await runLockfile();
+
+    const lockAfterSecond = readLock();
+    expect(lockAfterSecond.checksums[aKey]).toEqual(sectionABefore);
+    expect(lockAfterSecond.checksums[bKey]).toEqual(sectionBBefore);
+    expect(lockAfterSecond.checksums[cKey]).toBeDefined();
+    expect(lockAfterSecond.checksums[cKey].greeting).toBe(MD5("hello-c"));
+  });
+});

--- a/packages/cli/src/cli/cmd/lockfile.ts
+++ b/packages/cli/src/cli/cmd/lockfile.ts
@@ -97,7 +97,10 @@ export default new Command()
     } else if (addedCount > 0) {
       ora.succeed(`Lockfile updated (${summary})`);
     } else {
-      ora.succeed(`Lockfile is up to date (${summary || "no sections"})`);
+      ora.succeed(
+        `Nothing to refresh (${summary || "no sections"}). ` +
+          `Run \`lingo.dev run\` if source files have changed, or use --force to overwrite existing checksums.`,
+      );
     }
   });
 

--- a/packages/cli/src/cli/cmd/lockfile.ts
+++ b/packages/cli/src/cli/cmd/lockfile.ts
@@ -24,7 +24,15 @@ export default new Command()
     const lockfileHelper = createLockfileHelper();
     const lockExisted = lockfileHelper.isLockfileExists();
     const i18nConfig = getConfig();
-    const buckets = getBuckets(i18nConfig!);
+
+    if (!i18nConfig) {
+      ora.warn(
+        "No i18n.json found in the current directory. Create one before running `lingo.dev lockfile`.",
+      );
+      return;
+    }
+
+    const buckets = getBuckets(i18nConfig);
 
     let addedCount = 0;
     let skippedCount = 0;
@@ -41,7 +49,7 @@ export default new Command()
         }
 
         const sourceLocale = resolveOverriddenLocale(
-          i18nConfig!.locale.source,
+          i18nConfig.locale.source,
           bucketConfig.delimiter,
         );
         const bucketLoader = createBucketLoader(
@@ -49,7 +57,7 @@ export default new Command()
           pathPattern,
           {
             defaultLocale: sourceLocale,
-            formatter: i18nConfig!.formatter,
+            formatter: i18nConfig.formatter,
             keyColumn: bucket.keyColumn,
           },
           bucket.lockedKeys,

--- a/packages/cli/src/cli/cmd/lockfile.ts
+++ b/packages/cli/src/cli/cmd/lockfile.ts
@@ -22,44 +22,74 @@ export default new Command()
     const ora = Ora();
 
     const lockfileHelper = createLockfileHelper();
-    if (lockfileHelper.isLockfileExists() && !flags.force) {
-      ora.warn(
-        `Lockfile won't be created because it already exists. Use --force to overwrite.`,
-      );
-    } else {
-      const i18nConfig = getConfig();
-      const buckets = getBuckets(i18nConfig!);
+    const lockExisted = lockfileHelper.isLockfileExists();
+    const i18nConfig = getConfig();
+    const buckets = getBuckets(i18nConfig!);
 
-      for (const bucket of buckets) {
-        for (const bucketConfig of bucket.paths) {
-          const sourceLocale = resolveOverriddenLocale(
-            i18nConfig!.locale.source,
-            bucketConfig.delimiter,
-          );
-          const bucketLoader = createBucketLoader(
-            bucket.type,
-            bucketConfig.pathPattern,
-            {
-              defaultLocale: sourceLocale,
-              formatter: i18nConfig!.formatter,
-              keyColumn: bucket.keyColumn,
-            },
-            bucket.lockedKeys,
-            bucket.lockedPatterns,
-            bucket.ignoredKeys,
-            bucket.preservedKeys,
-            bucket.localizableKeys,
-          );
-          bucketLoader.setDefaultLocale(sourceLocale);
+    let addedCount = 0;
+    let skippedCount = 0;
+    let replacedCount = 0;
 
-          const sourceData = await bucketLoader.pull(sourceLocale);
-          lockfileHelper.registerSourceData(
-            bucketConfig.pathPattern,
-            sourceData,
-          );
+    for (const bucket of buckets) {
+      for (const bucketConfig of bucket.paths) {
+        const pathPattern = bucketConfig.pathPattern;
+
+        if (!flags.force && lockfileHelper.hasSourceData(pathPattern)) {
+          console.log(`  skipped (already populated): ${pathPattern}`);
+          skippedCount++;
+          continue;
+        }
+
+        const sourceLocale = resolveOverriddenLocale(
+          i18nConfig!.locale.source,
+          bucketConfig.delimiter,
+        );
+        const bucketLoader = createBucketLoader(
+          bucket.type,
+          pathPattern,
+          {
+            defaultLocale: sourceLocale,
+            formatter: i18nConfig!.formatter,
+            keyColumn: bucket.keyColumn,
+          },
+          bucket.lockedKeys,
+          bucket.lockedPatterns,
+          bucket.ignoredKeys,
+          bucket.preservedKeys,
+          bucket.localizableKeys,
+        );
+        bucketLoader.setDefaultLocale(sourceLocale);
+
+        const sourceData = await bucketLoader.pull(sourceLocale);
+        const sectionExisted = lockfileHelper.hasSourceData(pathPattern);
+        lockfileHelper.registerSourceData(pathPattern, sourceData);
+
+        if (sectionExisted) {
+          console.log(`  replaced (--force): ${pathPattern}`);
+          replacedCount++;
+        } else {
+          console.log(`  added: ${pathPattern}`);
+          addedCount++;
         }
       }
-      ora.succeed("Lockfile created");
+    }
+
+    const summary = [
+      addedCount > 0 ? `added ${addedCount}` : null,
+      replacedCount > 0 ? `replaced ${replacedCount}` : null,
+      skippedCount > 0 ? `skipped ${skippedCount}` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+    if (!lockExisted) {
+      ora.succeed(`Lockfile created (${summary || "no sections"})`);
+    } else if (flags.force) {
+      ora.succeed(`Lockfile rebuilt (${summary || "no sections"})`);
+    } else if (addedCount > 0) {
+      ora.succeed(`Lockfile updated (${summary})`);
+    } else {
+      ora.succeed(`Lockfile is up to date (${summary || "no sections"})`);
     }
   });
 

--- a/packages/cli/src/cli/cmd/run/frozen.ts
+++ b/packages/cli/src/cli/cmd/run/frozen.ts
@@ -126,7 +126,7 @@ export default async function frozen(input: CmdRunContext) {
               );
               if (Object.keys(updatedSourceData).length > 0) {
                 throw new Error(
-                  `Localization data has changed; please update i18n.lock or run without --frozen. Details: Source file has been updated.`,
+                  `Localization data has changed. Run \`lingo.dev lockfile\` to refresh i18n.lock, or run without --frozen. Details: Source file has been updated.`,
                 );
               }
 
@@ -144,7 +144,7 @@ export default async function frozen(input: CmdRunContext) {
                 );
                 if (missingKeys.length > 0) {
                   throw new Error(
-                    `Localization data has changed; please update i18n.lock or run without --frozen. Details: Target file is missing translations.`,
+                    `Localization data has changed. Run \`lingo.dev lockfile\` to refresh i18n.lock, or run without --frozen. Details: Target file is missing translations.`,
                   );
                 }
 
@@ -154,7 +154,7 @@ export default async function frozen(input: CmdRunContext) {
                 );
                 if (extraKeys.length > 0) {
                   throw new Error(
-                    `Localization data has changed; please update i18n.lock or run without --frozen. Details: Target file has extra translations not present in the source file.`,
+                    `Localization data has changed. Run \`lingo.dev lockfile\` to refresh i18n.lock, or run without --frozen. Details: Target file has extra translations not present in the source file.`,
                   );
                 }
 
@@ -164,7 +164,7 @@ export default async function frozen(input: CmdRunContext) {
                 );
                 if (unlocalizableDataDiff) {
                   throw new Error(
-                    `Localization data has changed; please update i18n.lock or run without --frozen. Details: Unlocalizable data (such as booleans, dates, URLs, etc.) do not match.`,
+                    `Localization data has changed. Run \`lingo.dev lockfile\` to refresh i18n.lock, or run without --frozen. Details: Unlocalizable data (such as booleans, dates, URLs, etc.) do not match.`,
                   );
                 }
               }

--- a/packages/cli/src/cli/utils/lockfile.test.ts
+++ b/packages/cli/src/cli/utils/lockfile.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { deduplicateLockfileYaml } from "./lockfile";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
 import YAML from "yaml";
+import { createLockfileHelper, deduplicateLockfileYaml } from "./lockfile";
 
 describe("deduplicateLockfileYaml", () => {
   it("should return unchanged content when there are no duplicates", () => {
@@ -263,5 +266,55 @@ checksums:
     expect(parsed.checksums.pathHash1["button.submit"]).toBe("jkl345");
     expect(parsed.checksums.pathHash1["button.cancel"]).toBe("mno678");
     expect(Object.keys(parsed.checksums.pathHash1)).toHaveLength(4);
+  });
+});
+
+describe("createLockfileHelper.hasSourceData", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lingo-lock-helper-"));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns false when the lockfile is absent", () => {
+    const helper = createLockfileHelper();
+    expect(helper.hasSourceData("src/[locale].json")).toBe(false);
+  });
+
+  it("returns false when the section is absent", () => {
+    const helper = createLockfileHelper();
+    helper.registerSourceData("src/a/[locale].json", { greeting: "hello" });
+    expect(helper.hasSourceData("src/b/[locale].json")).toBe(false);
+  });
+
+  it("returns false when the section exists but is empty", () => {
+    const lockfileContent = YAML.stringify({
+      version: 1,
+      checksums: {
+        deadbeef: {},
+      },
+    });
+    fs.writeFileSync(path.join(tmpDir, "i18n.lock"), lockfileContent);
+
+    const helper = createLockfileHelper();
+    // The empty-section md5 key won't match this pathPattern, but we also want
+    // to confirm that even for the matching key the empty check holds. Build a
+    // section keyed by the real md5 of the pattern:
+    helper.registerSourceData("src/[locale].json", {});
+    expect(helper.hasSourceData("src/[locale].json")).toBe(false);
+  });
+
+  it("returns true when the section has at least one checksum", () => {
+    const helper = createLockfileHelper();
+    helper.registerSourceData("src/[locale].json", { greeting: "hello" });
+    expect(helper.hasSourceData("src/[locale].json")).toBe(true);
   });
 });

--- a/packages/cli/src/cli/utils/lockfile.ts
+++ b/packages/cli/src/cli/utils/lockfile.ts
@@ -11,6 +11,12 @@ export function createLockfileHelper() {
       const lockfilePath = _getLockfilePath();
       return fs.existsSync(lockfilePath);
     },
+    hasSourceData: (pathPattern: string): boolean => {
+      const lockfile = _loadLockfile();
+      const sectionKey = MD5(pathPattern);
+      const section = lockfile.checksums[sectionKey];
+      return !!section && Object.keys(section).length > 0;
+    },
     registerSourceData: (
       pathPattern: string,
       sourceData: Record<string, any>,


### PR DESCRIPTION
## Summary

Builds on #2091. PR #2091 patched the `--frozen` false-positive only for the narrow case where a no-op `lingo.dev run` precedes `--frozen`. This PR closes the remaining cases by changing `lingo.dev lockfile` from a bail-out into the actual recovery command, and by updating `--frozen` errors to point users at it.

### Failure scenarios this closes (that #2091 left open)

- New file appears under a `**` recursive glob → new `pathPattern` → no lock section.
- New bucket added to `i18n.json`.
- Previous run used `--target-locale` (execute.ts gates `saveChecksums` on `!flags.targetLocale?.length`).
- Existing `i18n.lock` with `checksums: {}` (or any section that exists but is empty).

All four funnel through the same throw at `frozen.ts:127–131` because `loadChecksums` returns `{}` for a missing section and every key in `src` compares unequal to `undefined`.

### Behavior change: `lingo.dev lockfile`

Without `--force`:
- Iterate `getBuckets(i18nConfig)`.
- For each `bucketConfig.pathPattern`, check `MD5(pathPattern)` against the lock's `checksums` map.
- If the section exists with at least one checksum → **skip** (preserve the divergence signal that `--frozen` relies on).
- Otherwise → pull source data, call `registerSourceData` (full-section write).

`--force` retains the previous full-rebuild semantics.

Per-path stdout: `added`, `skipped (already populated)`, `replaced (--force)`, plus a summary line.

A new public method `hasSourceData(pathPattern: string): boolean` was added to `createLockfileHelper()` to expose the section-presence check cleanly.

`registerPartialSourceData` is deliberately **not** used — its `_.merge` would overwrite individual checksums in a non-empty section and re-introduce the masking risk (a source value flip `"Sasha"` → `"Petr"` would silently get re-baselined). The whole point of this design is that any non-empty section is load-bearing and only `--force` may touch it.

### Error-message update: `frozen.ts`

All four throws (lines 129/147/157/167) now read:

> Localization data has changed. Run \`lingo.dev lockfile\` to refresh i18n.lock, or run without --frozen. Details: …

The existing `Details: …` suffixes are unchanged.

### Why not auto-heal inside `--frozen`?

I considered self-healing inside `frozen.ts` (initialize missing sections automatically). Rejected because:
1. It shifts the meaning of `--frozen` from "strict no-drift validation" to "validate, but auto-fill missing entries" — out of line with `npm ci`, `yarn --immutable`, `cargo --locked`, `bundler --frozen`.
2. There's a one-shot masking risk: if a source value is flipped at the same moment the lock section is missing, validation silently passes with stale target translations.

The explicit "run a command, commit the lock" flow has no analogous failure mode and matches user expectations for a lockfile-based tool.

## Test plan

- [x] New: `src/cli/utils/lockfile.test.ts` — 4 `hasSourceData` tests (absent lock, absent section, empty section, populated section).
- [x] New: `src/cli/cmd/lockfile.spec.ts` — 5 integration scenarios:
  - Partial fill: lock has section A, missing section B → both populated after run, A byte-identical.
  - Empty lock (`checksums: {}`) → section created.
  - Stale checksum preserved: lock has stale entry for P, source modified → entry untouched (so `--frozen` still throws the divergence signal).
  - `--force` regression guard: existing section fully rebuilt.
  - `**` recursive glob: 2 files run, add 3rd, run again — only the 3rd section is added; first two byte-identical.
- [x] `pnpm test` in `packages/cli/`: **Test Files 55 passed (55) | Tests 886 passed (886)**.

## Follow-ups (intentionally not in this PR)

1. `delta.ts:104–112` and `lockfile.ts:72–78` rewrite the lock during a *read* when `deduplicateLockfileYaml` finds duplicates — so `--frozen` isn't actually read-only today. Worth a separate PR to skip the rewrite from `--frozen`, and to harden the YAML round-trip (`parseDocument → toJSON → new Document → toString`) against translation keys that look like YAML specials (`yes/no`, ISO dates, numbers).
2. Opt-in `lingo.dev run --frozen --heal` to inline the merge step before validation. Hold until there's user demand; the two-command flow is the default we want.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lockfile now fills missing lock sections additively while preserving existing checksums; `--force` still rebuilds fully.
  * CLI now reports clearer lockfile statuses (created / rebuilt / updated / up to date).

* **Bug Fixes**
  * Fixed false-positive `--frozen` failures (wildcard globs, new files/buckets, prior runs with empty sections).
  * Clarified `--frozen` error messages to instruct running the lockfile command to recover.

* **Tests**
  * Added end-to-end tests covering merge, update, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lingodotdev/lingo.dev/pull/2093?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->