### PR TITLE
fix(sdk): normalize Android and underscore locales to BCP 47 before API calls

### DIFF
--- a/.changeset/blue-crews-shake.md
+++ b/.changeset/blue-crews-shake.md
@@ -1,0 +1,5 @@
+---
+"@lingo.dev/_sdk": patch
+---
+
+Android-format (`pt-rPT`) and underscore (`pt_PT`) locales passed config validation but were sent to the API verbatim, which it rejects with a 400. Normalize `sourceLocale`, `targetLocale`, and `reference` keys to canonical BCP 47 on the wire via a schema transform. File paths are unaffected, so the CLI keeps the original code for Android resource directories (e.g. `values-pt-rPT/`)

--- a/packages/sdk/src/index.spec.ts
+++ b/packages/sdk/src/index.spec.ts
@@ -481,4 +481,70 @@ describe("LingoDotDevEngine", () => {
       expect(requestBody.hints).toBeUndefined();
     });
   });
+
+  describe("locale normalization", () => {
+    let mockFetch: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { greeting: "Olá" } }),
+      });
+      global.fetch = mockFetch as any;
+    });
+
+    it("normalizes Android `-r` locales to BCP 47 in the request body", async () => {
+      const engine = new LingoDotDevEngine({ apiKey: "test-key" });
+
+      await engine.localizeObject(
+        { greeting: "Hello" },
+        { sourceLocale: "en", targetLocale: "pt-rPT" },
+      );
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.targetLocale).toBe("pt-PT");
+      expect(body.sourceLocale).toBe("en");
+    });
+
+    it("normalizes underscore locales to BCP 47 in the request body", async () => {
+      const engine = new LingoDotDevEngine({ apiKey: "test-key" });
+
+      await engine.localizeObject(
+        { greeting: "Hello" },
+        { sourceLocale: "en_US", targetLocale: "pt_PT" },
+      );
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.sourceLocale).toBe("en-US");
+      expect(body.targetLocale).toBe("pt-PT");
+    });
+
+    it("normalizes locale codes used as reference keys", async () => {
+      const engine = new LingoDotDevEngine({ apiKey: "test-key" });
+
+      await engine.localizeObject(
+        { greeting: "Hello" },
+        {
+          sourceLocale: "en",
+          targetLocale: "pt-rPT",
+          reference: { "pt-rPT": { greeting: "Olá" } },
+        },
+      );
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(Object.keys(body.reference)).toEqual(["pt-PT"]);
+    });
+
+    it("leaves already-canonical locales unchanged", async () => {
+      const engine = new LingoDotDevEngine({ apiKey: "test-key" });
+
+      await engine.localizeObject(
+        { greeting: "Hello" },
+        { sourceLocale: "en", targetLocale: "pt-PT" },
+      );
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.targetLocale).toBe("pt-PT");
+    });
+  });
 });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,9 @@
 import Z from "zod";
-import { LocaleCode, localeCodeSchema } from "@lingo.dev/_spec";
+import {
+  LocaleCode,
+  localeCodeSchema,
+  normalizeLocale,
+} from "@lingo.dev/_spec";
 import { createId } from "@paralleldrive/cuid2";
 import { trackEvent } from "./utils/observability";
 import { TRACKING_EVENTS } from "./utils/tracking-events";
@@ -12,13 +16,18 @@ const engineParamsSchema = Z.object({
   engineId: Z.string().optional(),
 }).passthrough();
 
+// Locale codes are validated leniently (Android `pt-rPT`, underscore `pt_PT`,
+// etc. all pass) but must reach the API in canonical BCP 47 form. Normalizing
+// here keeps the CLI free to use the original code for file paths.
+const normalizedLocaleCodeSchema = localeCodeSchema.transform(normalizeLocale);
+
 const payloadSchema = Z.record(Z.string(), Z.any());
-const referenceSchema = Z.record(localeCodeSchema, payloadSchema);
+const referenceSchema = Z.record(normalizedLocaleCodeSchema, payloadSchema);
 const hintsSchema = Z.record(Z.string(), Z.array(Z.string()));
 
 const localizationParamsSchema = Z.object({
-  sourceLocale: Z.union([localeCodeSchema, Z.null()]),
-  targetLocale: localeCodeSchema,
+  sourceLocale: Z.union([normalizedLocaleCodeSchema, Z.null()]),
+  targetLocale: normalizedLocaleCodeSchema,
   fast: Z.boolean().optional(),
   reference: referenceSchema.optional(),
   hints: hintsSchema.optional(),
@@ -118,7 +127,7 @@ export class LingoDotDevEngine {
       const processedPayloadChunk = await this.localizeChunk(
         finalParams.sourceLocale,
         finalParams.targetLocale,
-        { data: chunk, reference: params.reference, hints: params.hints },
+        { data: chunk, reference: finalParams.reference, hints: params.hints },
         params.fast || false,
         params.filePath,
         params.triggerType,


### PR DESCRIPTION
## Summary

Normalize Android-format (`pt-rPT`) and underscore (`pt_PT`) locale codes to canonical BCP 47 before sending them to the API, so locales that pass config validation are no longer rejected with a 400.

## Changes

- Add a `normalizedLocaleCodeSchema` (`localeCodeSchema.transform(normalizeLocale)`) in the SDK and apply it to `sourceLocale`, `targetLocale`, and `reference` keys, so every locale that crosses the wire is canonical BCP 47.
- Send the normalized `finalParams.reference` (instead of the raw `params.reference`) in `_localizeRaw`, so reference keys are canonicalized along with the locales they pair with.
- File paths are untouched: the CLI still uses the original code for resource directories (e.g. `values-pt-rPT/`).

## Testing

**Business logic tests added:**

- [x] Android `-r` locale (`pt-rPT`) is normalized to `pt-PT` in the request body
- [x] Underscore locales (`en_US`, `pt_PT`) are normalized to `en-US` / `pt-PT` in the request body
- [x] Locale codes used as `reference` keys are normalized (`pt-rPT` → `pt-PT`)
- [x] Already-canonical locales (`pt-PT`) pass through unchanged
- [x] All tests pass locally

## Visuals

N/A

## Checklist

- [x] Changeset added (if version bump needed) — `@lingo.dev/_sdk` patch; the CLI (`lingo.dev`) is auto-bumped as a dependent
- [x] Tests cover business logic (not just happy path) — Android, underscore, reference-key, and canonical-passthrough cases
- [x] No breaking changes (or documented below)

Closes N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed locale handling in localization requests. Android-format (`pt-rPT`) and underscore-delimited locales (`pt_PT`) are now automatically normalized to canonical BCP 47 format (`pt-PT`) before being sent to the API, preventing rejection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->