### PR TITLE
feat(sdk): add retry-with-backoff for transient localization failures

### DIFF
--- a/.changeset/yummy-snails-return.md
+++ b/.changeset/yummy-snails-return.md
@@ -1,0 +1,5 @@
+---
+"@lingo.dev/_sdk": patch
+---
+
+Retry localization requests on transient failures. `localizeChunk` now retries on 5xx responses and network errors using exponential backoff with full jitter, controlled by the new `maxRetries` (default 3) and `retryDelayMs` (default 500) engine options

--- a/packages/sdk/src/index.spec.ts
+++ b/packages/sdk/src/index.spec.ts
@@ -482,6 +482,148 @@ describe("LingoDotDevEngine", () => {
     });
   });
 
+  describe("retry on 5xx errors", () => {
+    let mockFetch: ReturnType<typeof vi.fn>;
+
+    const okResponse = () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { greeting: "Hola" } }),
+    });
+
+    const serverErrorResponse = (status = 503) => ({
+      ok: false,
+      status,
+      text: async () => JSON.stringify({ message: "service unavailable" }),
+    });
+
+    beforeEach(() => {
+      mockFetch = vi.fn();
+      global.fetch = mockFetch as any;
+    });
+
+    it("retries the request when the API responds with a 5xx and eventually succeeds", async () => {
+      mockFetch
+        .mockResolvedValueOnce(serverErrorResponse(500))
+        .mockResolvedValueOnce(serverErrorResponse(503))
+        .mockResolvedValueOnce(okResponse());
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        retryDelayMs: 0,
+      });
+
+      const result = await engine.localizeObject(
+        { greeting: "Hello" },
+        { sourceLocale: "en", targetLocale: "es" },
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(result).toEqual({ greeting: "Hola" });
+    });
+
+    it("throws after exhausting all retries on persistent 5xx errors", async () => {
+      mockFetch.mockResolvedValue(serverErrorResponse(500));
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        maxRetries: 2,
+        retryDelayMs: 0,
+      });
+
+      await expect(
+        engine.localizeObject(
+          { greeting: "Hello" },
+          { sourceLocale: "en", targetLocale: "es" },
+        ),
+      ).rejects.toThrow(/Server error \(500\)/);
+
+      // initial attempt + 2 retries
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not retry on 4xx errors", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => JSON.stringify({ message: "bad request" }),
+      });
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        retryDelayMs: 0,
+      });
+
+      await expect(
+        engine.localizeObject(
+          { greeting: "Hello" },
+          { sourceLocale: "en", targetLocale: "es" },
+        ),
+      ).rejects.toThrow(/Invalid request/);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on transient network errors", async () => {
+      mockFetch
+        .mockRejectedValueOnce(new TypeError("network failure"))
+        .mockResolvedValueOnce(okResponse());
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        retryDelayMs: 0,
+      });
+
+      const result = await engine.localizeObject(
+        { greeting: "Hello" },
+        { sourceLocale: "en", targetLocale: "es" },
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ greeting: "Hola" });
+    });
+
+    it("does not retry when maxRetries is 0", async () => {
+      mockFetch.mockResolvedValue(serverErrorResponse(500));
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        maxRetries: 0,
+        retryDelayMs: 0,
+      });
+
+      await expect(
+        engine.localizeObject(
+          { greeting: "Hello" },
+          { sourceLocale: "en", targetLocale: "es" },
+        ),
+      ).rejects.toThrow(/Server error \(500\)/);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry an aborted request", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const engine = new LingoDotDevEngine({
+        apiKey: "test-key",
+        retryDelayMs: 0,
+      });
+
+      await expect(
+        engine.localizeObject(
+          { greeting: "Hello" },
+          { sourceLocale: "en", targetLocale: "es" },
+          undefined,
+          controller.signal,
+        ),
+      ).rejects.toThrow(/aborted/i);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
   describe("locale normalization", () => {
     let mockFetch: ReturnType<typeof vi.fn>;
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -14,6 +14,12 @@ const engineParamsSchema = Z.object({
   batchSize: Z.number().int().gt(0).lte(250).default(25),
   idealBatchItemSize: Z.number().int().gt(0).lte(2500).default(250),
   engineId: Z.string().optional(),
+  // Number of times a localization request is retried after a transient
+  // failure (5xx response or network error). `0` disables retries.
+  maxRetries: Z.number().int().gte(0).default(3),
+  // Base delay (ms) for the exponential backoff between retries. The actual
+  // wait grows as `retryDelayMs * 2 ** attempt` plus a small random jitter.
+  retryDelayMs: Z.number().int().gte(0).default(500),
 }).passthrough();
 
 // Locale codes are validated leniently (Android `pt-rPT`, underscore `pt_PT`,
@@ -83,6 +89,92 @@ export class LingoDotDevEngine {
       throw new Error(`Invalid request: ${msg}`);
     }
     throw new Error(context ? `${context}: ${msg}` : msg);
+  }
+
+  /**
+   * Sleep for `ms` milliseconds, rejecting early if the signal is aborted.
+   */
+  private static sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new Error("Operation was aborted"));
+        return;
+      }
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(new Error("Operation was aborted"));
+      };
+      const timer = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+
+  /**
+   * Exponential backoff with full jitter: a random delay in
+   * `[0, retryDelayMs * 2 ** attempt]`. Jitter spreads out retries from many
+   * clients so a recovering server is not hit by a synchronized wave.
+   */
+  private backoffDelay(attempt: number): number {
+    const ceiling = this.config.retryDelayMs * 2 ** attempt;
+    return Math.round(Math.random() * ceiling);
+  }
+
+  /**
+   * Perform a fetch, retrying on transient failures (5xx responses and
+   * network errors) with exponential backoff. The retry decision is made on
+   * the HTTP status code (>= 500), so non-retryable responses (e.g. 4xx) are
+   * returned immediately for the caller to handle. Aborted requests are never
+   * retried.
+   * @param url - The request URL
+   * @param init - Fetch init options (should include the AbortSignal)
+   * @param signal - Optional AbortSignal used to short-circuit retries
+   * @returns The fetch Response (which may still be a non-retryable error)
+   */
+  private async fetchWithRetry(
+    url: string,
+    init: RequestInit,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    const { maxRetries } = this.config;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      if (signal?.aborted) {
+        throw new Error("Operation was aborted");
+      }
+
+      try {
+        const res = await fetch(url, init);
+
+        const isServerError = res.status >= 500 && res.status < 600;
+        if (isServerError && attempt < maxRetries) {
+          // Drain the body we are about to discard so the underlying
+          // connection is released back to the pool before we retry.
+          await res.body?.cancel();
+          await LingoDotDevEngine.sleep(this.backoffDelay(attempt), signal);
+          continue;
+        }
+
+        return res;
+      } catch (error) {
+        // Aborts are intentional - never retry them.
+        if (signal?.aborted) {
+          throw error;
+        }
+        // Network/transport error: retry while attempts remain.
+        if (attempt < maxRetries) {
+          await LingoDotDevEngine.sleep(this.backoffDelay(attempt), signal);
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    // The loop always returns or throws on the final attempt; this satisfies
+    // the return type and guards against an unexpected fall-through.
+    throw new Error("Localization request failed after exhausting retries");
   }
 
   /**
@@ -183,12 +275,16 @@ export class LingoDotDevEngine {
       ...(this.config.engineId && { engineId: this.config.engineId }),
     };
 
-    const res = await fetch(url, {
-      method: "POST",
-      headers: this.headers,
-      body: JSON.stringify(body, null, 2),
+    const res = await this.fetchWithRetry(
+      url,
+      {
+        method: "POST",
+        headers: this.headers,
+        body: JSON.stringify(body, null, 2),
+        signal,
+      },
       signal,
-    });
+    );
 
     await LingoDotDevEngine.throwOnHttpError(res);
 


### PR DESCRIPTION
## Summary

Add automatic retry-with-backoff for transient localization failures in the SDK, so a 5xx response or network blip no longer fails the whole request.

## Changes

- Add `fetchWithRetry` to `LingoDotDevEngine`, used by `localizeChunk`: retries on 5xx responses and network errors with exponential backoff + full jitter.
- Add two config options — `maxRetries` (default `3`) and `retryDelayMs` (default `500`); `maxRetries: 0` disables retries.
- Retry decision is based on the HTTP status code (`>= 500`); 4xx responses and aborted requests (`signal.aborted`) are never retried.
- Cancel discarded 5xx response bodies before retrying so the underlying connection is released back to the pool.

## Testing

**Business logic tests added:**

- [x] Retries a 5xx response and returns the result once a later attempt succeeds (asserts 3 fetch calls)
- [x] Throws after exhausting `maxRetries` on persistent 5xx (asserts initial attempt + N retries)
- [x] Does not retry 4xx responses (fails fast on `Invalid request`)
- [x] Retries transient network errors (rejected `fetch`) and recovers
- [x] `maxRetries: 0` performs a single attempt with no retries
- [x] Does not retry an already-aborted request (no fetch issued)
- [x] All tests pass locally

## Visuals

**Required for UI/UX changes:**

N/A

## Checklist

- [x] Changeset added (if version bump needed)
- [x] Tests cover business logic (not just happy path)
- [x] No breaking changes (or documented below)

Closes N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Localization requests now automatically retry on transient failures (5xx errors and network issues) using exponential backoff.
  * Added configurable options: `maxRetries` (default: 3) and `retryDelayMs` (default: 500ms) to control retry behavior.

* **Tests**
  * Added comprehensive test coverage for retry behavior across various failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->