### PR TITLE
feat(demo): add new CLI demo covering all supported file formats

### DIFF
--- a/.changeset/cute-mice-smash.md
+++ b/.changeset/cute-mice-smash.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add the `demo/new-cli` example project. Demo only, no published package changes.

--- a/demo/new-cli/.lingo/config.json
+++ b/demo/new-cli/.lingo/config.json
@@ -1,0 +1,58 @@
+{
+  "sourceLocale": "en",
+  "targetLocales": [
+    "de",
+    "fr",
+    "es"
+  ],
+  "files": [
+    {
+      "pattern": "content/en/app.json",
+      "injectLocale": true,
+      "lockedKeys": [
+        "meta.version"
+      ]
+    },
+    {
+      "pattern": "content/en/settings.jsonc",
+      "preservedKeys": [
+        "featureFlags"
+      ]
+    },
+    {
+      "pattern": "content/en/guide.md",
+      "translateFrontmatterFields": [
+        "title",
+        "description"
+      ]
+    },
+    {
+      "pattern": "content/en/landing.mdx",
+      "translateFrontmatterFields": [
+        "title"
+      ],
+      "translateComponentProps": [
+        {
+          "component": [
+            "Hero",
+            "Callout"
+          ],
+          "props": [
+            "title",
+            "body"
+          ]
+        }
+      ]
+    },
+    {
+      "pattern": "content/en/changelog.mdoc",
+      "translateFrontmatterFields": [
+        "title"
+      ]
+    },
+    {
+      "pattern": "content/en/api.yaml",
+      "format": "yaml-openapi"
+    }
+  ]
+}

--- a/demo/new-cli/.lingo/lock.json
+++ b/demo/new-cli/.lingo/lock.json
@@ -1,0 +1,59 @@
+{
+  "version": 1,
+  "files": {
+    "content/de/api.yaml": {
+      "sha256": "a6c044903e798cd1e939f4e791fb1671463d904ef45a8c73a60b85f89793421b"
+    },
+    "content/de/app.json": {
+      "sha256": "5ea4357309b816f767d0e9d8c3ffcaf44e8b9bd4ddc7b34cf5f9300c16d864fe"
+    },
+    "content/de/changelog.mdoc": {
+      "sha256": "364ba7e4fb50c6e739398f2509abd9658fc78dd51d7d42c9ef0a89c7998cf49e"
+    },
+    "content/de/guide.md": {
+      "sha256": "f43b72e2f8c9ff48b02b6b02ebcbae350eeba7a6e255d3bb55a999c8fc402cfe"
+    },
+    "content/de/landing.mdx": {
+      "sha256": "a2ae8ebd1c1e4a2b66ab0382cac285670c146679bc36f8d1f0b4d91c306ff87e"
+    },
+    "content/de/settings.jsonc": {
+      "sha256": "f1532df03ba349fb04f9e2538e988dc0fc9ce18fcca81a30c3528fe0dec933d2"
+    },
+    "content/es/api.yaml": {
+      "sha256": "e655fed0877fb9250d7c4ba3a9d84116282dc212b1933b97a61c7a4b984db6ec"
+    },
+    "content/es/app.json": {
+      "sha256": "6343810f282d97fb68a9be13d3aee8dfcce2b1573b90985e8bdbb26ce617a6c0"
+    },
+    "content/es/changelog.mdoc": {
+      "sha256": "b446a60d5db688ff3f6703e89c6c64c86c3e87055287affea4d6425cc77a8293"
+    },
+    "content/es/guide.md": {
+      "sha256": "2ea3a51a46b3f2f381c7eb17316e1e22b989cba94368184a76f686d0ea86ad49"
+    },
+    "content/es/landing.mdx": {
+      "sha256": "5485f6f0d123d688ab5e8d7e2cf21a42a534a739e2e04ba895d7976ced3435b8"
+    },
+    "content/es/settings.jsonc": {
+      "sha256": "ef8cb32fbdde960c3de8b4ca8186131f07291fd844fa12ece097288db5d43fc1"
+    },
+    "content/fr/api.yaml": {
+      "sha256": "c0e3c1e4b172cc1c5f9770e7bf6fd6ab395fe5f5d2ab19fdb6d7c6304252301f"
+    },
+    "content/fr/app.json": {
+      "sha256": "9296bc0b932bb334d2dbe0b48371abd3a7b4d44c21c15e14526b526cdd00ea3d"
+    },
+    "content/fr/changelog.mdoc": {
+      "sha256": "3f3976fffefa23d45b765ad7c1c9104f1cb35ca4527817235afe2ddf093b42e7"
+    },
+    "content/fr/guide.md": {
+      "sha256": "1972323957345dd0dfff2d18b8146dd091996bed8f471aa5d018cada9c0846cc"
+    },
+    "content/fr/landing.mdx": {
+      "sha256": "4c05452206bc7a75a63f4c277b66512f7b512cd9fe034ed854d460147f4e22e7"
+    },
+    "content/fr/settings.jsonc": {
+      "sha256": "0806fd9d4209761e1dd4136a2bbefeeebb787f45e4f7bb72114e26e94016d083"
+    }
+  }
+}

--- a/demo/new-cli/README.md
+++ b/demo/new-cli/README.md
@@ -1,0 +1,60 @@
+# Lingo CLI demo
+
+A ready-to-run project that shows the [`@lingo.dev/cli`](https://www.npmjs.com/package/@lingo.dev/cli)
+translating **every supported file format** end to end: JSON, JSONC, Markdown,
+MDX, Markdoc, and OpenAPI YAML.
+
+Drop in your own org and engine, run `push`, and watch every format get
+translated into German, French, and Spanish.
+
+## What's inside
+
+```
+.lingo/config.json     # one files[] entry per format, with format-specific options
+content/en/
+  app.json             # JSON    — injectLocale + lockedKeys
+  settings.jsonc       # JSONC   — preservedKeys (comments survive)
+  guide.md             # MD      — translateFrontmatterFields
+  landing.mdx          # MDX     — translateComponentProps (Hero, Callout)
+  changelog.mdoc       # Markdoc — frontmatter + tag attributes preserved
+  api.yaml             # OpenAPI YAML — explicit "format": "yaml-openapi"
+```
+
+Source locale is `en`; targets are `de`, `fr`, `es`. The repo ships the
+translated `content/de/`, `content/fr/`, and `content/es/` files as sample
+output so you can see the result without running anything. Re-run the CLI
+against your own engine to regenerate them (the CLI swaps the `en` path segment
+for each target locale).
+
+## Get the demo
+
+```bash
+npx degit lingodotdev/lingo.dev/demo/new-cli my-lingo-demo
+cd my-lingo-demo
+```
+
+## Run it
+
+You need a [Lingo.dev](https://lingo.dev) account. The commands below use `npx`,
+so there's nothing to install globally.
+
+```bash
+# 1. Authenticate (once).
+npx @lingo.dev/cli@latest login
+
+# 2. Connect this project to your org and engine.
+npx @lingo.dev/cli@latest link
+
+# 3. (optional) Preview the cost before translating.
+npx @lingo.dev/cli@latest push --backfill-missing --estimate
+
+# 4. Translate every file into every target locale.
+npx @lingo.dev/cli@latest push --backfill-missing
+
+# 5. Pull the translated files back into content/<locale>/.
+npx @lingo.dev/cli@latest pull
+```
+
+`push` needs a linked org and engine, so run `link` first. The `content/de`,
+`content/fr`, and `content/es` files checked into the repo are sample output;
+your own `push` / `pull` overwrites them with translations from your engine.

--- a/demo/new-cli/content/de/api.yaml
+++ b/demo/new-cli/content/de/api.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: Demo-API
+  version: 1.0.0
+  description: Eine kompakte OpenAPI-Spezifikation. Für Menschen bestimmte Texte
+    (Zusammenfassungen, Beschreibungen) werden übersetzt; Schlüssel und
+    Bezeichner bleiben unverändert.
+paths:
+  /products:
+    get:
+      summary: Alle Produkte anzeigen
+      description: Gibt eine paginierte Liste der im Katalog verfügbaren Produkte zurück.
+      responses:
+        "200":
+          description: Eine Liste von Produkten.
+  /products/{id}:
+    get:
+      summary: Ein einzelnes Produkt abrufen
+      description: Gibt das Produkt mit der angegebenen Kennung zurück.
+      responses:
+        "404":
+          description: Das Produkt wurde nicht gefunden.

--- a/demo/new-cli/content/de/app.json
+++ b/demo/new-cli/content/de/app.json
@@ -1,0 +1,15 @@
+{
+  "meta": {
+    "version": "1.0.0"
+  },
+  "nav": {
+    "home": "Startseite",
+    "pricing": "Preise",
+    "docs": "Dokumentation"
+  },
+  "cta": {
+    "title": "Veröffentliche deine App in allen Sprachen",
+    "subtitle": "Übersetze dein Produkt, ohne deinen Editor zu verlassen.",
+    "button": "Jetzt loslegen"
+  }
+}

--- a/demo/new-cli/content/de/changelog.mdoc
+++ b/demo/new-cli/content/de/changelog.mdoc
@@ -1,0 +1,19 @@
+---
+title: Changelog
+---
+
+# Changelog
+
+{% callout type="info" %}
+Diese Seite ist in Markdoc verfasst. Der Fließtext wird übersetzt; Tag-Attribute wie
+`type` bleiben erhalten.
+{% /callout %}
+
+## 1.0.0
+
+- Erste öffentliche Version.
+- Unterstützung für JSON, JSONC, Markdown, MDX, Markdoc und OpenAPI YAML hinzugefügt.
+
+## 0.9.0
+
+- Beta-Version für Early Adopters.

--- a/demo/new-cli/content/de/guide.md
+++ b/demo/new-cli/content/de/guide.md
@@ -1,0 +1,19 @@
+---
+title: Erste Schritte
+description: Eine kurze Anleitung für Ihr erstes lokalisiertes Release.
+slug: getting-started
+---
+
+# Erste Schritte
+
+Willkommen zur Demo. Diese Seite zeigt, wie Markdown-Inhalte durch die
+Lingo CLI laufen. Der Fließtext wird übersetzt, während das Frontmatter-Feld
+`slug` unverändert bleibt.
+
+## So geht's
+
+1. Verfassen Sie Ihre Inhalte in der Ausgangssprache.
+2. Führen Sie `lingo push` aus, um sie zur Übersetzung zu senden.
+3. Führen Sie `lingo pull` aus, um die übersetzten Dateien abzurufen.
+
+> Tipp: Halten Sie Ihre Sätze kurz. So lassen sie sich zuverlässiger übersetzen.

--- a/demo/new-cli/content/de/landing.mdx
+++ b/demo/new-cli/content/de/landing.mdx
@@ -1,0 +1,16 @@
+---
+title: Lokalisieren, ohne deinen Editor zu verlassen
+---
+
+<Hero
+  title="Ein Befehl, der alles übersetzt"
+  body="Übertrage deine Quelldateien und hole sie in jeder Sprache zurück."
+/>
+
+Lingo behandelt deine Markdown-, JSON- und OpenAPI-Spezifikationen als Inhalte erster Klasse.
+Fließtext wie dieser Absatz wird automatisch übersetzt.
+
+<Callout
+  title="Wichtiger Hinweis"
+  body="Komponenten-Props, die in translateComponentProps aufgeführt sind, werden übersetzt; alles andere bleibt Code."
+/>

--- a/demo/new-cli/content/de/settings.jsonc
+++ b/demo/new-cli/content/de/settings.jsonc
@@ -1,0 +1,11 @@
+{
+  "labels": {
+    "theme": "Design",
+    "language": "Sprache",
+    "notifications": "Benachrichtigungen"
+  },
+  "featureFlags": {
+    "newOnboarding": true,
+    "betaEditor": false
+  }
+}

--- a/demo/new-cli/content/en/api.yaml
+++ b/demo/new-cli/content/en/api.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: Demo API
+  version: 1.0.0
+  description: A tiny OpenAPI spec. Human-facing strings (summaries, descriptions) are translated; keys and identifiers are preserved.
+paths:
+  /products:
+    get:
+      summary: List all products
+      description: Returns a paginated list of products available in the catalog.
+      responses:
+        "200":
+          description: A list of products.
+  /products/{id}:
+    get:
+      summary: Get a single product
+      description: Returns the product with the given identifier.
+      responses:
+        "404":
+          description: The product could not be found.

--- a/demo/new-cli/content/en/app.json
+++ b/demo/new-cli/content/en/app.json
@@ -1,0 +1,15 @@
+{
+  "meta": {
+    "version": "1.0.0"
+  },
+  "nav": {
+    "home": "Home",
+    "pricing": "Pricing",
+    "docs": "Documentation"
+  },
+  "cta": {
+    "title": "Ship your app in every language",
+    "subtitle": "Translate your product without leaving your editor.",
+    "button": "Get started"
+  }
+}

--- a/demo/new-cli/content/en/changelog.mdoc
+++ b/demo/new-cli/content/en/changelog.mdoc
@@ -1,0 +1,19 @@
+---
+title: Changelog
+---
+
+# Changelog
+
+{% callout type="info" %}
+This page is written in Markdoc. The prose is translated; tag attributes such
+as `type` are preserved.
+{% /callout %}
+
+## 1.0.0
+
+- Initial public release.
+- Added support for JSON, JSONC, Markdown, MDX, Markdoc, and OpenAPI YAML.
+
+## 0.9.0
+
+- Beta release for early adopters.

--- a/demo/new-cli/content/en/guide.md
+++ b/demo/new-cli/content/en/guide.md
@@ -1,0 +1,19 @@
+---
+title: Getting started
+description: A short guide to your first localized release.
+slug: getting-started
+---
+
+# Getting started
+
+Welcome to the demo. This page shows how Markdown content flows through the
+Lingo CLI. The body text is translated, while the `slug` frontmatter field is
+left untouched.
+
+## Steps
+
+1. Write your content in the source locale.
+2. Run `lingo push` to send it for translation.
+3. Run `lingo pull` to fetch the translated files.
+
+> Tip: keep your sentences short. They translate more reliably.

--- a/demo/new-cli/content/en/landing.mdx
+++ b/demo/new-cli/content/en/landing.mdx
@@ -1,0 +1,16 @@
+---
+title: Localize without leaving your editor
+---
+
+<Hero
+  title="One command to translate everything"
+  body="Push your source files, pull them back in every language."
+/>
+
+Lingo treats your Markdown, JSON, and OpenAPI specs as first-class content.
+Prose like this paragraph is translated automatically.
+
+<Callout
+  title="Heads up"
+  body="Component props listed in translateComponentProps are translated; everything else stays as code."
+/>

--- a/demo/new-cli/content/en/settings.jsonc
+++ b/demo/new-cli/content/en/settings.jsonc
@@ -1,0 +1,13 @@
+{
+  // User-facing labels are translated.
+  "labels": {
+    "theme": "Theme",
+    "language": "Language",
+    "notifications": "Notifications"
+  },
+  // featureFlags are preserved verbatim (see preservedKeys in .lingo/config.json).
+  "featureFlags": {
+    "newOnboarding": true,
+    "betaEditor": false
+  }
+}

--- a/demo/new-cli/content/es/api.yaml
+++ b/demo/new-cli/content/es/api.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: API de ejemplo
+  version: 1.0.0
+  description: Una especificación OpenAPI pequeña. Los textos visibles para las
+    personas (resúmenes y descripciones) se traducen; las claves y los
+    identificadores se conservan.
+paths:
+  /products:
+    get:
+      summary: Lista todos los productos
+      description: Devuelve una lista paginada de los productos disponibles en el catálogo.
+      responses:
+        "200":
+          description: Una lista de productos.
+  /products/{id}:
+    get:
+      summary: Obtén un producto
+      description: Devuelve el producto con el identificador indicado.
+      responses:
+        "404":
+          description: No se ha podido encontrar el producto.

--- a/demo/new-cli/content/es/app.json
+++ b/demo/new-cli/content/es/app.json
@@ -1,0 +1,15 @@
+{
+  "meta": {
+    "version": "1.0.0"
+  },
+  "nav": {
+    "home": "Inicio",
+    "pricing": "Precios",
+    "docs": "Documentación"
+  },
+  "cta": {
+    "title": "Lanza tu app en cualquier idioma",
+    "subtitle": "Traduce tu producto sin salir del editor.",
+    "button": "Empieza ahora"
+  }
+}

--- a/demo/new-cli/content/es/changelog.mdoc
+++ b/demo/new-cli/content/es/changelog.mdoc
@@ -1,0 +1,19 @@
+---
+title: Registro de cambios
+---
+
+# Registro de cambios
+
+{% callout type="info" %}
+Esta página está escrita en Markdoc. El contenido se traduce, pero se conservan los atributos de etiquetas como
+`type`.
+{% /callout %}
+
+## 1.0.0
+
+- Primera versión pública.
+- Se añadió compatibilidad con JSON, JSONC, Markdown, MDX, Markdoc y OpenAPI YAML.
+
+## 0.9.0
+
+- Versión beta para quienes adoptan la tecnología antes que nadie.

--- a/demo/new-cli/content/es/guide.md
+++ b/demo/new-cli/content/es/guide.md
@@ -1,0 +1,19 @@
+---
+title: Primeros pasos
+description: Una breve guía para tu primera publicación localizada.
+slug: getting-started
+---
+
+# Primeros pasos
+
+Te damos la bienvenida a la demo. Esta página muestra cómo el contenido en Markdown fluye a través de
+Lingo CLI. El texto del cuerpo se traduce, mientras que el campo `slug` del frontmatter se
+deja intacto.
+
+## Pasos
+
+1. Escribe tu contenido en el idioma de origen.
+2. Ejecuta `lingo push` para enviarlo a traducir.
+3. Ejecuta `lingo pull` para obtener los archivos traducidos.
+
+> Consejo: mantén las frases cortas. Se traducen con mayor fiabilidad.

--- a/demo/new-cli/content/es/landing.mdx
+++ b/demo/new-cli/content/es/landing.mdx
@@ -1,0 +1,16 @@
+---
+title: Localiza sin salir del editor
+---
+
+<Hero
+  title="Un solo comando para traducirlo todo"
+  body="Sube tus archivos fuente y recupéralos en todos los idiomas."
+/>
+
+Lingo trata tu Markdown, JSON y las especificaciones de OpenAPI como contenido de primera categoría.
+La prosa, como la de este párrafo, se traduce automáticamente.
+
+<Callout
+  title="Importante"
+  body="Las props de los componentes incluidas en translateComponentProps se traducen; todo lo demás se mantiene como código."
+/>

--- a/demo/new-cli/content/es/settings.jsonc
+++ b/demo/new-cli/content/es/settings.jsonc
@@ -1,0 +1,11 @@
+{
+  "labels": {
+    "theme": "Tema",
+    "language": "Idioma",
+    "notifications": "Notificaciones"
+  },
+  "featureFlags": {
+    "newOnboarding": true,
+    "betaEditor": false
+  }
+}

--- a/demo/new-cli/content/fr/api.yaml
+++ b/demo/new-cli/content/fr/api.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: API de démonstration
+  version: 1.0.0
+  description: Une spécification OpenAPI concise. Les chaînes visibles par les
+    utilisateurs (résumés, descriptions) sont traduites ; les clés et les
+    identifiants sont conservés.
+paths:
+  /products:
+    get:
+      summary: Lister tous les produits
+      description: Renvoie une liste paginée des produits disponibles dans le catalogue.
+      responses:
+        "200":
+          description: Une liste de produits.
+  /products/{id}:
+    get:
+      summary: Obtenir un produit
+      description: Renvoie le produit correspondant à l’identifiant fourni.
+      responses:
+        "404":
+          description: Le produit est introuvable.

--- a/demo/new-cli/content/fr/app.json
+++ b/demo/new-cli/content/fr/app.json
@@ -1,0 +1,15 @@
+{
+  "meta": {
+    "version": "1.0.0"
+  },
+  "nav": {
+    "home": "Accueil",
+    "pricing": "Tarifs",
+    "docs": "Documentation"
+  },
+  "cta": {
+    "title": "Lancez votre application dans toutes les langues",
+    "subtitle": "Traduisez votre produit sans quitter votre éditeur.",
+    "button": "Commencer"
+  }
+}

--- a/demo/new-cli/content/fr/changelog.mdoc
+++ b/demo/new-cli/content/fr/changelog.mdoc
@@ -1,0 +1,18 @@
+---
+title: Journal des mises à jour
+---
+
+# Journal des mises à jour
+
+{% callout type="info" %}
+Cette page est rédigée en Markdoc. Le contenu est traduit ; les attributs de balise tels que `type` sont conservés.
+{% /callout %}
+
+## 1.0.0
+
+- Première version publique.
+- Prise en charge de JSON, JSONC, Markdown, MDX, Markdoc et OpenAPI YAML ajoutée.
+
+## 0.9.0
+
+- Version bêta destinée aux premiers utilisateurs.

--- a/demo/new-cli/content/fr/guide.md
+++ b/demo/new-cli/content/fr/guide.md
@@ -1,0 +1,19 @@
+---
+title: Premiers pas
+description: Un guide rapide pour votre première publication localisée.
+slug: getting-started
+---
+
+# Premiers pas
+
+Bienvenue dans la démo. Cette page montre comment le contenu Markdown passe par
+Lingo CLI. Le corps du texte est traduit, tandis que le champ de frontmatter `slug` est
+laissé tel quel.
+
+## Étapes
+
+1. Rédigez votre contenu dans la langue source.
+2. Exécutez `lingo push` pour l’envoyer en traduction.
+3. Exécutez `lingo pull` pour récupérer les fichiers traduits.
+
+> Conseil : privilégiez les phrases courtes. Elles se traduisent plus fiablement.

--- a/demo/new-cli/content/fr/landing.mdx
+++ b/demo/new-cli/content/fr/landing.mdx
@@ -1,0 +1,16 @@
+---
+title: Localisez sans quitter votre éditeur
+---
+
+<Hero
+  title="Une seule commande pour tout traduire"
+  body="Envoyez vos fichiers source, puis récupérez-les dans toutes les langues."
+/>
+
+Lingo traite votre Markdown, votre JSON et vos spécifications OpenAPI comme du contenu à part entière.
+Les textes comme ce paragraphe sont traduits automatiquement.
+
+<Callout
+  title="À noter"
+  body="Les props de composants répertoriées dans translateComponentProps sont traduites ; tout le reste reste du code."
+/>

--- a/demo/new-cli/content/fr/settings.jsonc
+++ b/demo/new-cli/content/fr/settings.jsonc
@@ -1,0 +1,11 @@
+{
+  "labels": {
+    "theme": "Thème",
+    "language": "Langue",
+    "notifications": "Notifications"
+  },
+  "featureFlags": {
+    "newOnboarding": true,
+    "betaEditor": false
+  }
+}

--- a/demo/new-cli/package.json
+++ b/demo/new-cli/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@lingo.dev/demo-new-cli",
+  "version": "0.0.0",
+  "private": true
+}


### PR DESCRIPTION
Adds a runnable demo for the new `@lingo.dev/cli` under `demo/new-cli/`, alongside the existing compiler demos.

## What's inside
- `.lingo/config.json` with one `files[]` entry per supported format (no org/engine binding, so users run `lingo link` to connect their own).
- `content/en/` sources covering every format: JSON, JSONC, Markdown, MDX, Markdoc, OpenAPI YAML, each exercising a format-specific option (lockedKeys, preservedKeys, translateFrontmatterFields, translateComponentProps).
- `content/de|fr|es/` sample output plus `.lingo/lock.json`, matching the old CLI demo pattern (committed translations).
- `README.md`: get via `degit`, then `login` -> `link` -> `push --estimate` (preview cost) -> `push` -> `pull`.

## Verified
Ran the full flow end to end against a real engine on `@lingo.dev/cli@1.7.0`: push submitted the async run, pull wrote 18 target files, translations are real (lockedKeys honored), and `push --estimate` returns a per-locale cost breakdown.

No changeset: `@lingo.dev/demo-new-cli` is private, nothing published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new demo CLI project showcasing end-to-end localization across English, German, Spanish, and French.
  * Includes locale configuration and a pinned translation lock, plus sample content covering app strings, settings, documentation, and OpenAPI API specs.

* **Documentation**
  * Added a complete demo README with the expected folder structure, supported file formats, and step-by-step CLI commands (login/link/push/pull) to get started quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->