### PR TITLE
fix: improve BYOK response parsing

### DIFF
--- a/.changeset/fair-rivers-parse.md
+++ b/.changeset/fair-rivers-parse.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+Accept plain JSON objects as BYOK translation data when model responses omit the top-level `data` envelope.

--- a/packages/cli/src/cli/utils/model-response.test.ts
+++ b/packages/cli/src/cli/utils/model-response.test.ts
@@ -39,6 +39,11 @@ describe("extractLocalizedData", () => {
     expect(extractLocalizedData(input)).toEqual({ hello: "hallo" });
   });
 
+  it("treats a plain object without a data field as translation data", () => {
+    const input = JSON.stringify({ hello: "hallo" });
+    expect(extractLocalizedData(input)).toEqual({ hello: "hallo" });
+  });
+
   it("repairs an envelope with a missing colon", () => {
     // Raw JSON.parse fails with "Expected ':' after property name in JSON"
     const input = `{"sourceLocale": "en", "targetLocale": "de", "data" {"hello": "hallo"}}`;
@@ -58,7 +63,7 @@ describe("extractLocalizedData", () => {
     expect(extractLocalizedData(input)).toEqual({ hello: "hallo" });
   });
 
-  it("throws a clear error when valid JSON has no data object", () => {
+  it("throws a clear error when valid JSON is an assistant message envelope", () => {
     // e.g. the model wraps its answer in a role/content envelope
     const input = JSON.stringify({
       role: "assistant",

--- a/packages/cli/src/cli/utils/model-response.ts
+++ b/packages/cli/src/cli/utils/model-response.ts
@@ -33,6 +33,16 @@ export function extractLocalizedData(text: string): Record<string, any> {
     return result.data;
   }
 
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    !Array.isArray(result) &&
+    !("data" in result) &&
+    !("role" in result && "content" in result)
+  ) {
+    return result;
+  }
+
   // Handle string responses - extract and repair JSON
   if (typeof result?.data === "string") {
     const index = result.data.indexOf("{");


### PR DESCRIPTION
## Summary

Accept plain JSON objects as BYOK translation data when model responses omit the top-level `data` envelope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced BYOK translation ingestion to accept plain JSON objects as translation data, eliminating the requirement for a top-level `data` envelope when model responses omit this structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->