### PR TITLE
fix(security): bump demo vite 7.3.0 → 7.3.5

### DIFF
--- a/.changeset/sec-demo-vite-bump.md
+++ b/.changeset/sec-demo-vite-bump.md
@@ -1,0 +1,4 @@
+---
+---
+
+Bump the declared `vite` devDependency in the `demo/new-compiler-vite-react-spa` private demo from 7.3.0 to 7.3.5, matching the version already resolved by the pnpm workspace. Clears the remaining Dependabot vite advisories (3 high + 2 moderate) that were flagged from the declared manifest version. Private demo, no published package or consumer impact.

--- a/demo/new-compiler-vite-react-spa/package.json
+++ b/demo/new-compiler-vite-react-spa/package.json
@@ -29,7 +29,7 @@
     "@vitejs/plugin-react": "5.0.4",
     "jsdom": "27.0.0",
     "typescript": "5.7.2",
-    "vite": "7.3.0",
+    "vite": "7.3.5",
     "web-vitals": "5.1.0"
   }
 }


### PR DESCRIPTION
## What

Bumps the declared `vite` devDependency in `demo/new-compiler-vite-react-spa` from `7.3.0` → `7.3.5`.

## Why

After #2130 removed the stray npm lockfile, the only remaining high Dependabot alerts (3 high + 2 moderate, all `vite`) came from this demo's **declared** `package.json` version `7.3.0` (< the `7.3.5` patch for GHSA-fx2h-pf6j-xcff and related). The pnpm workspace already **resolves** `vite@7.3.5` (root overrides), so this only aligns the declared version with what's installed.

Takes the repo to **0 critical / 0 high** in Dependabot.

## Safety

- Demo is `private: true` → not published, zero consumer impact.
- `pnpm-lock.yaml` unchanged (already at 7.3.5).
- Empty changeset (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vite dependency version in demo project from 7.3.0 to 7.3.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->