### PR TITLE
fix(cli): recover unescaped quotes in JSON repair step

### DIFF
--- a/.changeset/fix-unescaped-quotes-json-repair.md
+++ b/.changeset/fix-unescaped-quotes-json-repair.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+Recover from unescaped quotes in model translation responses during JSON repair. When `jsonrepair` can't parse a response (e.g. Claude Sonnet emitting unescaped double quotes inside string values), the parser now escapes those quotes and retries before failing, avoiding a costly fallback retranslation.

--- a/packages/cli/src/cli/utils/model-response.test.ts
+++ b/packages/cli/src/cli/utils/model-response.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseModelResponse, extractLocalizedData } from "./model-response";
+import {
+  parseModelResponse,
+  extractLocalizedData,
+  escapeUnescapedQuotes,
+} from "./model-response";
 
 describe("parseModelResponse", () => {
   it("parses clean JSON", () => {
@@ -26,6 +30,40 @@ describe("parseModelResponse", () => {
     // Trailing comma — invalid JSON but jsonrepair handles it
     const input = `{"data": {"hello": "hola",}}`;
     expect(parseModelResponse(input)).toEqual({ data: { hello: "hola" } });
+  });
+
+  it("repairs a value with multiple unescaped quotes", () => {
+    // jsonrepair alone fails on this; escapeUnescapedQuotes recovers it.
+    const input = `{"data": {"message": "She said "hi" and "bye""}}`;
+    expect(parseModelResponse(input)).toEqual({
+      data: { message: 'She said "hi" and "bye"' },
+    });
+  });
+
+  it("repairs a trailing unescaped quote at the end of a value", () => {
+    const input = `{"data": {"message": "He said "hello""}}`;
+    expect(parseModelResponse(input)).toEqual({
+      data: { message: 'He said "hello"' },
+    });
+  });
+});
+
+describe("escapeUnescapedQuotes", () => {
+  it("escapes quotes inside string values while keeping structure intact", () => {
+    const input = `{"data": {"message": "She said "hi" and "bye""}}`;
+    expect(JSON.parse(escapeUnescapedQuotes(input))).toEqual({
+      data: { message: 'She said "hi" and "bye"' },
+    });
+  });
+
+  it("leaves already-escaped quotes untouched", () => {
+    const input = `{"a": "say \\"hi\\"", "b": "ok"}`;
+    expect(escapeUnescapedQuotes(input)).toBe(input);
+  });
+
+  it("does not alter valid JSON", () => {
+    const input = `{"a": "ok", "b": "valid"}`;
+    expect(escapeUnescapedQuotes(input)).toBe(input);
   });
 });
 

--- a/packages/cli/src/cli/utils/model-response.ts
+++ b/packages/cli/src/cli/utils/model-response.ts
@@ -13,8 +13,70 @@ export function parseModelResponse(
   try {
     return JSON.parse(extracted);
   } catch {
-    return JSON.parse(jsonrepair(extracted));
+    try {
+      return JSON.parse(jsonrepair(extracted));
+    } catch {
+      // Models (notably Claude Sonnet) occasionally emit string values
+      // containing unescaped double quotes that jsonrepair can't recover on
+      // its own. Escape those quotes and retry before giving up — this keeps
+      // the response usable instead of triggering a costly fallback retranslation.
+      return JSON.parse(jsonrepair(escapeUnescapedQuotes(extracted)));
+    }
   }
+}
+
+/**
+ * Escape double quotes that appear inside JSON string values but were left
+ * unescaped by the model. A quote is treated as a real string terminator only
+ * when the next non-whitespace character is a structural delimiter (`:`, `,`,
+ * `}`, `]`) or the end of input; any other quote inside a string is escaped.
+ */
+export function escapeUnescapedQuotes(input: string): string {
+  let out = "";
+  let inString = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (!inString) {
+      out += ch;
+      if (ch === '"') inString = true;
+      continue;
+    }
+
+    if (ch === "\\") {
+      // Preserve already-escaped sequences verbatim.
+      out += ch;
+      if (i + 1 < input.length) {
+        out += input[i + 1];
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      let j = i + 1;
+      while (j < input.length && /\s/.test(input[j])) j++;
+      const next = input[j];
+      if (
+        next === undefined ||
+        next === ":" ||
+        next === "," ||
+        next === "}" ||
+        next === "]"
+      ) {
+        out += ch;
+        inString = false;
+      } else {
+        out += '\\"';
+      }
+      continue;
+    }
+
+    out += ch;
+  }
+
+  return out;
 }
 
 export function extractLocalizedData(text: string): Record<string, any> {


### PR DESCRIPTION
## Summary

Recover from unescaped double quotes in model translation responses so they no longer trigger a costly fallback retranslation.

## Changes

- Added an `escapeUnescapedQuotes` pass in `model-response.ts` that runs only when `JSON.parse` and `jsonrepair` both fail. It scans the string, treating a `"` as a real terminator only when followed by a structural delimiter (`:`, `,`, `}`, `]`) or end-of-input, and escaping any other in-string quote before retrying `jsonrepair`. Claude Sonnet occasionally emits values like `"She said "hi" and "bye""` that plain `jsonrepair` can't recover.

## Testing

**Business logic tests added:**

- [x] `parseModelResponse` recovers a value with multiple unescaped quotes
- [x] `parseModelResponse` recovers a trailing unescaped quote at the end of a value
- [x] `escapeUnescapedQuotes` leaves already-escaped quotes and valid JSON untouched
- [x] All tests pass locally (17 passing)

## Checklist

- [x] Changeset added
- [x] Tests cover business logic (not just happy path)
- [x] No breaking changes
