### PR TITLE
chore: add changeset for npm audit dependency fixes

### DIFF
--- a/.changeset/audit-vuln-deps.md
+++ b/.changeset/audit-vuln-deps.md
@@ -1,0 +1,11 @@
+---
+"lingo.dev": patch
+"@lingo.dev/_react": patch
+---
+
+fix(deps): reduce npm audit vulnerabilities in the published tree
+
+- `@lingo.dev/_react`: widen the `next` peerDependency from the exact, vulnerable `15.3.8` to `>=15.5.19 <16` so consumers resolve a patched 15.x.
+- `lingo.dev`: bump `yaml` (2.8.1 → 2.9.0), `diff` (7.0.0 → 9.0.0), and `@datocms/cma-client-node` (4.0.1 → 5.5.3, pulls a patched `uuid`).
+
+Cuts a fresh consumer `npm audit` from 13 → 8 (critical 1 → 0, high 4 → 1).


### PR DESCRIPTION
Adds a changeset for the dependency security fixes merged in #2137 (they landed without one, so the release bot didn't pick them up).

On merge, the `changesets/action` Release workflow will open the **"chore: bump package versions"** PR, bumping:
- `lingo.dev` (patch) — `yaml`/`diff`/`@datocms/cma-client-node`
- `@lingo.dev/_react` (patch) — `next` peerDependency range

Merging that bump PR publishes the new versions to npm (`changeset publish`).

Net effect for consumers: fresh `npm audit` drops 13 → 8 (critical 1 → 0, high 4 → 1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced npm audit vulnerabilities in the dependency tree by updating package versions and widening peer dependency ranges to safer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->