### PR TITLE
fix(mdx): preserve code fences 

### DIFF
--- a/.changeset/mdx-long-code-fences.md
+++ b/.changeset/mdx-long-code-fences.md
@@ -1,0 +1,13 @@
+---
+"lingo.dev": patch
+---
+
+fix(mdx): preserve fenced code blocks with 4+ backtick fences
+
+The MDX code-placeholder loader hard-coded a 3-backtick fence pattern, so a
+fence of 4 or more backticks had only 3 of its closing backticks matched and
+the rest orphaned — the close was emitted as ``` ``` ``` + a blank line + a
+stray lone backtick, producing invalid MDX (e.g. a code block that swallowed
+the following `</Accordion>`). Fences are now matched at their actual length,
+with the closing fence allowed to be equal to or longer than the opening
+(per CommonMark).

--- a/packages/cli/src/cli/loaders/mdx2/code-placeholder.spec.ts
+++ b/packages/cli/src/cli/loaders/mdx2/code-placeholder.spec.ts
@@ -982,3 +982,73 @@ describe("placeholder format edge cases (regression)", () => {
     expect(restored).toBe(mdContent);
   });
 });
+
+describe("long fences (>=4 backticks) regression", () => {
+  const loader = createMdxCodePlaceholderLoader();
+  loader.setDefaultLocale("en");
+
+  it("round-trips a 4-backtick fence inside a JSX component", async () => {
+    // Authors use a 4-backtick fence so the block can safely contain markdown.
+    // The old 3-backtick-only regex captured "````...```" (4 open, 3 close) and
+    // orphaned the 4th closing backtick, splitting the close into
+    // "``` + blank line + stray `" and breaking the surrounding <Accordion>.
+    const md = dedent`
+      <Accordion title="Scribe skill">
+
+      \`\`\`\`markdown
+      skill body line one
+      skill body line two
+      \`\`\`\`
+
+      </Accordion>
+    `;
+    const pulled = await loader.pull("en", md);
+    expect(pulled).not.toMatch(/(^|\n)\s*\`\s*(\n|$)/); // no orphaned lone backtick
+    const pushed = await loader.push("en", pulled);
+    expect(pushed).toBe(md);
+  });
+
+  it("round-trips a 4-backtick fence wrapping a nested 3-backtick fence", async () => {
+    // The whole point of a 4-backtick fence: its body contains a 3-backtick
+    // fence. The closing must match the 4-backtick opening, not stop at the
+    // inner 3-backtick fence.
+    const md = dedent`
+      \`\`\`\`markdown
+      # Example
+
+      \`\`\`js
+      const a = 1;
+      \`\`\`
+      \`\`\`\`
+    `;
+    const pulled = await loader.pull("en", md);
+    const placeholders = pulled.match(/CODE_PLACEHOLDER_[a-f0-9]+_END/g) ?? [];
+    expect(placeholders).toHaveLength(1); // one block, not split at the inner fence
+    const pushed = await loader.push("en", pulled);
+    expect(pushed).toBe(md);
+  });
+
+  it("round-trips a 5-backtick fence", async () => {
+    const md = dedent`
+      \`\`\`\`\`markdown
+      body
+      \`\`\`\`\`
+    `;
+    const pulled = await loader.pull("en", md);
+    const pushed = await loader.push("en", pulled);
+    expect(pushed).toBe(md);
+  });
+
+  it("round-trips a fence whose close is longer than its open (CommonMark-valid)", async () => {
+    // CommonMark: the closing fence may be longer than the opening fence.
+    const md = dedent`
+      \`\`\`\`markdown
+      body
+      \`\`\`\`\`
+    `;
+    const pulled = await loader.pull("en", md);
+    expect(pulled).not.toMatch(/(^|\n)\s*\`\s*(\n|$)/); // no orphaned backtick
+    const pushed = await loader.push("en", pulled);
+    expect(pushed).toBe(md);
+  });
+});

--- a/packages/cli/src/cli/loaders/mdx2/code-placeholder.spec.ts
+++ b/packages/cli/src/cli/loaders/mdx2/code-placeholder.spec.ts
@@ -1051,4 +1051,34 @@ describe("long fences (>=4 backticks) regression", () => {
     const pushed = await loader.push("en", pulled);
     expect(pushed).toBe(md);
   });
+
+  it("does not close on a same-length backtick run inline in the body", async () => {
+    // The terminator must start on its own fence line — an inline run of the
+    // same length mid-line is body content, not a close.
+    const md = dedent`
+      \`\`\`\`markdown
+      prose with \`\`\`\` inline backticks
+      more body
+      \`\`\`\`
+    `;
+    const pulled = await loader.pull("en", md);
+    const placeholders = pulled.match(/CODE_PLACEHOLDER_[a-f0-9]+_END/g) ?? [];
+    expect(placeholders).toHaveLength(1); // one block, not split at the inline run
+    const pushed = await loader.push("en", pulled);
+    expect(pushed).toBe(md);
+  });
+
+  it("does not treat a fence-length run with trailing text as a close", async () => {
+    // CommonMark: a closing fence may be followed only by whitespace, so
+    // "```notAClose" is body, not the terminator.
+    const md = dedent`
+      \`\`\`
+      \`\`\`notAClose
+      real body
+      \`\`\`
+    `;
+    const pulled = await loader.pull("en", md);
+    const pushed = await loader.push("en", pulled);
+    expect(pushed).toBe(md);
+  });
 });

--- a/packages/cli/src/cli/loaders/mdx2/code-placeholder.ts
+++ b/packages/cli/src/cli/loaders/mdx2/code-placeholder.ts
@@ -3,7 +3,14 @@ import { createLoader } from "../_utils";
 import { md5 } from "../../utils/md5";
 import _ from "lodash";
 
-const fenceRegex = /([ \t]*)(^>\s*)?```([\s\S]*?)```/gm;
+// Capture the opening fence length (3+ backticks) and close on a run of at
+// least that many backticks (`\3` for the same length, `` `* `` for a longer
+// close — CommonMark allows the closing fence to be longer than the opening).
+// The old hard-coded ```` ``` ```` only matched 3-backtick fences: for a
+// ```` ```` ````-length fence it grabbed 3 of the 4 closing backticks and
+// orphaned the 4th, splitting the close into "``` + blank line + stray `" and
+// producing invalid MDX.
+const fenceRegex = /([ \t]*)(^>\s*)?(`{3,})([\s\S]*?)\3`*/gm;
 const inlineCodeRegex = /(?<!`)`([^`\r\n]+?)`(?!`)/g;
 
 // Matches markdown image tags, with optional alt text & parenthesis URL, possibly inside blockquotes

--- a/packages/cli/src/cli/loaders/mdx2/code-placeholder.ts
+++ b/packages/cli/src/cli/loaders/mdx2/code-placeholder.ts
@@ -3,14 +3,19 @@ import { createLoader } from "../_utils";
 import { md5 } from "../../utils/md5";
 import _ from "lodash";
 
-// Capture the opening fence length (3+ backticks) and close on a run of at
-// least that many backticks (`\3` for the same length, `` `* `` for a longer
-// close — CommonMark allows the closing fence to be longer than the opening).
+// Match a fenced code block of any fence length (3+ backticks):
+//   • `(`{3,})` captures the opening fence; `\3` requires the close to be the
+//     same length, `` `* `` allows a longer close (CommonMark permits it).
+//   • The close must start on its own line — `\r?\n`, the optional indent /
+//     blockquote prefix, then the fence run, then only trailing whitespace
+//     before the line ends. This stops a same-length backtick run *inside* the
+//     body (inline) from being mistaken for the terminator.
 // The old hard-coded ```` ``` ```` only matched 3-backtick fences: for a
 // ```` ```` ````-length fence it grabbed 3 of the 4 closing backticks and
 // orphaned the 4th, splitting the close into "``` + blank line + stray `" and
 // producing invalid MDX.
-const fenceRegex = /([ \t]*)(^>\s*)?(`{3,})([\s\S]*?)\3`*/gm;
+const fenceRegex =
+  /([ \t]*)(^>\s*)?(`{3,})([\s\S]*?)\r?\n[ \t]*>?[ \t]*\3`*[ \t]*(?=\r?\n|$)/gm;
 const inlineCodeRegex = /(?<!`)`([^`\r\n]+?)`(?!`)/g;
 
 // Matches markdown image tags, with optional alt text & parenthesis URL, possibly inside blockquotes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of MDX fenced code blocks that use 4+ backticks to prevent malformed output.
  * Correctly matches fence terminators, including CommonMark-valid cases where the closing fence is longer than the opening fence.

* **Tests**
  * Added regression tests for long backtick fences, nested fence scenarios, and exact round-trip restoration of the original Markdown content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->