### PR TITLE
fix: make react an optional peer dependency of the CLI

### DIFF
--- a/.changeset/react-optional-peer.md
+++ b/.changeset/react-optional-peer.md
@@ -1,0 +1,5 @@
+---
+"lingo.dev": patch
+---
+
+Make `react` an optional peer dependency instead of a direct dependency.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -201,7 +201,6 @@
     "plist": "3.1.0",
     "posthog-node": "5.14.0",
     "prettier": "3.6.2",
-    "react": "19.2.3",
     "rehype-stringify": "10.0.1",
     "remark-disable-tokenizers": "1.1.1",
     "remark-frontmatter": "5.0.0",
@@ -244,6 +243,14 @@
     "tsup": "8.5.1",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
+  },
+  "peerDependencies": {
+    "react": ">=18 <20"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,7 +444,7 @@ importers:
         specifier: 3.6.2
         version: 3.6.2
       react:
-        specifier: 19.2.3
+        specifier: '>=18 <20'
         version: 19.2.3
       rehype-stringify:
         specifier: 10.0.1


### PR DESCRIPTION
## Summary

Make `react` an optional peer dependency of the `lingo.dev` CLI so installs no longer force `react@19.2.3` and stop breaking repos with `strict-peer-deps` enabled that use a different React major.

## Changes

- Removed `react` from `lingo.dev` (`packages/cli`) direct `dependencies` and declared it as an **optional peer dependency** (`react: ">=18 <20"`, `peerDependenciesMeta.react.optional = true`).
- Updated `pnpm-lock.yaml` to match (one-line specifier change; `--frozen-lockfile` stays green).
- Added a patch changeset.

## Testing

**Business logic tests added:**

- [ ] N/A — this is a dependency-manifest change with no runtime code change, so no business-logic tests apply.
- [x] All tests pass locally

## Visuals

N/A

## Checklist

- [x] Changeset added (if version bump needed)
- [ ] Tests cover business logic (not just happy path) — N/A, dependency-manifest change only
- [x] No breaking changes

Closes N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package settings so React is now treated as an optional peer dependency.
  * This makes installation more flexible for projects that already provide React, while still supporting compatible React versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->