### PR TITLE
fix(compiler): use a target-language few-shot example to prevent cros…

### DIFF
--- a/.changeset/compiler-target-locale-shots.md
+++ b/.changeset/compiler-target-locale-shots.md
@@ -1,0 +1,7 @@
+---
+"@lingo.dev/compiler": patch
+---
+
+compiler: stop translations drifting to Spanish with custom OpenAI-compatible models
+
+The bundled few-shot example was always English→Spanish, so a weaker model could copy it and translate cache misses into Spanish regardless of the requested target locale (e.g. `zh-Hans`). The compiler now only sends a few-shot example whose language matches the target — curated examples ship for common languages (incl. Simplified/Traditional Chinese, Japanese, Korean) and any other target gets none rather than a wrong-language one — and it names the target language in the system prompt via `Intl.DisplayNames`. Fixes #2041.

--- a/packages/new-compiler/src/translators/lingo/prompt.test.ts
+++ b/packages/new-compiler/src/translators/lingo/prompt.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { getSystemPrompt } from "./prompt";
+
+describe("getSystemPrompt", () => {
+  it("names the source and target languages in the built-in prompt", () => {
+    const result = getSystemPrompt({ sourceLocale: "en", targetLocale: "es" });
+    expect(result).toContain("Source language (locale code): en (English)");
+    expect(result).toContain("Target language (locale code): es (Spanish)");
+  });
+
+  it("names non-Latin target languages", () => {
+    const result = getSystemPrompt({
+      sourceLocale: "en",
+      targetLocale: "zh-Hans",
+    });
+    expect(result).toContain(
+      "Target language (locale code): zh-Hans (Simplified Chinese)",
+    );
+  });
+
+  it("uses the user-defined prompt with locale substitution when provided", () => {
+    const result = getSystemPrompt({
+      sourceLocale: "en",
+      targetLocale: "es",
+      prompt: "Translate from {SOURCE_LOCALE} to {TARGET_LOCALE}.",
+    });
+    expect(result).toBe("Translate from en to es.");
+  });
+});

--- a/packages/new-compiler/src/translators/lingo/prompt.ts
+++ b/packages/new-compiler/src/translators/lingo/prompt.ts
@@ -4,6 +4,18 @@ interface PromptArguments {
   prompt?: string;
 }
 
+function getLanguageName(locale: string): string | undefined {
+  try {
+    const name = new Intl.DisplayNames(["en"], { type: "language" }).of(locale);
+    if (name && name.toLowerCase() !== locale.toLowerCase()) {
+      return name;
+    }
+  } catch {
+    // Malformed locale code — fall back to the code only.
+  }
+  return undefined;
+}
+
 export function getSystemPrompt(args: PromptArguments): string {
   // If user provided custom prompt, use it
   if (args.prompt?.trim()) {
@@ -12,6 +24,9 @@ export function getSystemPrompt(args: PromptArguments): string {
       .replace("{SOURCE_LOCALE}", args.sourceLocale)
       .replace("{TARGET_LOCALE}", args.targetLocale);
   }
+
+  const sourceName = getLanguageName(args.sourceLocale);
+  const targetName = getLanguageName(args.targetLocale);
 
   // Otherwise use built-in prompt
   return `
@@ -24,8 +39,8 @@ You replicate the meaning, intent, style, tone, and purpose of the original data
 
 ## Setup
 
-Source language (locale code): ${args.sourceLocale}
-Target language (locale code): ${args.targetLocale}
+Source language (locale code): ${args.sourceLocale}${sourceName ? ` (${sourceName})` : ""}
+Target language (locale code): ${args.targetLocale}${targetName ? ` (${targetName})` : ""}
 
 ## Guidelines
 

--- a/packages/new-compiler/src/translators/lingo/shots.test.ts
+++ b/packages/new-compiler/src/translators/lingo/shots.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { getShots } from "./shots";
+
+describe("getShots", () => {
+  it("returns the Spanish example for Spanish targets", () => {
+    for (const locale of ["es", "es-ES", "es-419", "es-MX"]) {
+      const shots = getShots(locale);
+      expect(shots).toHaveLength(1);
+      expect(shots[0][1].locale).toBe("es");
+    }
+  });
+
+  it("returns the Simplified Chinese example for Simplified targets", () => {
+    for (const locale of ["zh-Hans", "zh-Hans-CN", "zh-CN", "zh-SG", "zh"]) {
+      const shots = getShots(locale);
+      expect(shots).toHaveLength(1);
+      expect(shots[0][1].locale).toBe("zh-Hans");
+    }
+  });
+
+  it("returns the Traditional Chinese example for Traditional targets", () => {
+    for (const locale of ["zh-Hant", "zh-Hant-HK", "zh-TW", "zh-HK"]) {
+      const shots = getShots(locale);
+      expect(shots).toHaveLength(1);
+      expect(shots[0][1].locale).toBe("zh-Hant");
+    }
+  });
+
+  it("returns the matching example for other covered languages", () => {
+    expect(getShots("ja")[0][1].locale).toBe("ja");
+    expect(getShots("ko")[0][1].locale).toBe("ko");
+    expect(getShots("fr-CA")[0][1].locale).toBe("fr");
+    expect(getShots("pt_BR")[0][1].locale).toBe("pt");
+  });
+
+  it("returns no example for uncovered locales or the source language", () => {
+    for (const locale of ["sw", "hu", "vi", "en", "en-US"]) {
+      expect(getShots(locale)).toEqual([]);
+    }
+  });
+
+  it("never returns an example whose language differs from the target", () => {
+    for (const locale of ["zh-Hans", "zh-Hant", "ja", "ko", "fr", "de"]) {
+      for (const [, output] of getShots(locale)) {
+        expect(output.locale.split("-")[0]).toBe(locale.split("-")[0]);
+      }
+    }
+  });
+
+  it("keeps the English input and target output structurally aligned", () => {
+    for (const [input, output] of getShots("zh-Hans")) {
+      expect(input.locale).toBe("en");
+      expect(Object.keys(output.entries)).toEqual(Object.keys(input.entries));
+    }
+  });
+});

--- a/packages/new-compiler/src/translators/lingo/shots.ts
+++ b/packages/new-compiler/src/translators/lingo/shots.ts
@@ -4,27 +4,82 @@ import type { DictionarySchema } from "../api";
  * Few-shot examples for LLM translation
  * These help the LLM understand the expected format and behavior
  */
+const source: DictionarySchema = {
+  version: 0.1,
+  locale: "en",
+  entries: {
+    "1z2x3c4v": "Dashboard",
+    "5t6y7u8i": "Settings",
+    "9o0p1q2r": "Logout",
+    "9k0l1m2n": "© 2025 Lingo.dev. All rights reserved.",
+  },
+};
+
+function target(
+  locale: DictionarySchema["locale"],
+  dashboard: string,
+  settings: string,
+  logout: string,
+  rights: string,
+): DictionarySchema {
+  return {
+    version: 0.1,
+    locale,
+    entries: {
+      "1z2x3c4v": dashboard,
+      "5t6y7u8i": settings,
+      "9o0p1q2r": logout,
+      "9k0l1m2n": `© 2025 Lingo.dev. ${rights}`,
+    },
+  };
+}
+
+// One example per target language. getShots() only returns the example whose
+// language matches the requested target, so the model is never shown a
+// demonstration in the wrong language (see #2041).
 export const shots: [DictionarySchema, DictionarySchema][] = [
-  [
-    {
-      version: 0.1,
-      locale: "en",
-      entries: {
-        "1z2x3c4v": "Dashboard",
-        "5t6y7u8i": "Settings",
-        "9o0p1q2r": "Logout",
-        "9k0l1m2n": "© 2025 Lingo.dev. All rights reserved.",
-      },
-    },
-    {
-      version: 0.1,
-      locale: "es",
-      entries: {
-        "1z2x3c4v": "Panel de control",
-        "5t6y7u8i": "Configuración",
-        "9o0p1q2r": "Cerrar sesión",
-        "9k0l1m2n": "© 2025 Lingo.dev. Todos los derechos reservados.",
-      },
-    },
-  ],
+  [source, target("es", "Panel de control", "Configuración", "Cerrar sesión", "Todos los derechos reservados.")],
+  [source, target("fr", "Tableau de bord", "Paramètres", "Déconnexion", "Tous droits réservés.")],
+  [source, target("de", "Übersicht", "Einstellungen", "Abmelden", "Alle Rechte vorbehalten.")],
+  [source, target("it", "Pannello di controllo", "Impostazioni", "Esci", "Tutti i diritti riservati.")],
+  [source, target("pt", "Painel", "Configurações", "Sair", "Todos os direitos reservados.")],
+  [source, target("nl", "Overzicht", "Instellingen", "Afmelden", "Alle rechten voorbehouden.")],
+  [source, target("ru", "Панель управления", "Настройки", "Выйти", "Все права защищены.")],
+  [source, target("ja", "ダッシュボード", "設定", "ログアウト", "無断転載を禁じます。")],
+  [source, target("ko", "대시보드", "설정", "로그아웃", "모든 권리 보유.")],
+  [source, target("zh-Hans", "仪表板", "设置", "退出登录", "保留所有权利。")],
+  [source, target("zh-Hant", "儀表板", "設定", "登出", "保留所有權利。")],
 ];
+
+export function getShots(
+  targetLocale: string,
+): [DictionarySchema, DictionarySchema][] {
+  return shots.filter(([, output]) => localeMatches(output.locale, targetLocale));
+}
+
+function localeMatches(shotLocale: string, targetLocale: string): boolean {
+  const shot = normalize(shotLocale);
+  const target = normalize(targetLocale);
+  if (shot.split("-")[0] !== target.split("-")[0]) {
+    return false;
+  }
+  // Chinese is the only language we ship examples for that splits by script, so
+  // a bare language-subtag match isn't enough: never serve a Simplified example
+  // for a Traditional target or vice versa.
+  if (shot.split("-")[0] === "zh") {
+    return chineseScript(shot) === chineseScript(target);
+  }
+  return true;
+}
+
+function normalize(locale: string): string {
+  return locale.replace(/_/g, "-").toLowerCase();
+}
+
+function chineseScript(locale: string): "hans" | "hant" {
+  if (locale.includes("hant")) return "hant";
+  if (locale.includes("hans")) return "hans";
+  const region = locale.split("-")[1];
+  if (region === "tw" || region === "hk" || region === "mo") return "hant";
+  return "hans";
+}

--- a/packages/new-compiler/src/translators/lingo/translator.ts
+++ b/packages/new-compiler/src/translators/lingo/translator.ts
@@ -3,7 +3,7 @@ import { LingoDotDevEngine } from "lingo.dev/sdk";
 import { dictionaryFrom, type DictionarySchema, type TranslatableEntry, type Translator, } from "../api";
 import { getSystemPrompt } from "./prompt";
 import { obj2xml, parseXmlFromResponseText } from "../parse-xml";
-import { shots } from "./shots";
+import { getShots } from "./shots";
 import { createAiModel, getLocaleModel, validateAndGetApiKeys, type ValidatedApiKeys, } from "./model-factory";
 import { Logger } from "../../utils/logger";
 import { DEFAULT_TIMEOUTS, withTimeout } from "../../utils/timeout";
@@ -192,7 +192,7 @@ export class LingoTranslator implements Translator<LingoTranslatorConfig> {
               }),
             },
             // Add few-shot examples
-            ...shots.flatMap((shotsTuple) => [
+            ...getShots(targetLocale).flatMap((shotsTuple) => [
               {
                 role: "user" as const,
                 content: obj2xml(shotsTuple[0]),


### PR DESCRIPTION
Fixes cross-locale drift in the compiler's LLM translator: with a custom OpenAI-compatible model, newly generated translations could come out in Spanish regardless of the requested target locale, because the bundled few-shot example was always English→Spanish.

## Changes

* `translators/lingo/shots.ts`: replaced the single hard-coded English→Spanish few-shot with a `getShots(targetLocale)` selector that returns only an example whose language matches the target. Kept the existing Spanish example and added correct ones for a curated set (fr, de, it, pt, nl, ru, ja, ko, and Simplified/Traditional Chinese); any other target gets no example rather than a wrong-language one. Chinese matching is script-aware (Simplified vs Traditional).
* `translators/lingo/translator.ts`: inject `getShots(targetLocale)` instead of the static `shots` array.
* `translators/lingo/prompt.ts`: name the source/target language in the built-in system prompt via `Intl.DisplayNames` (e.g. `Target language (locale code): zh-Hans (Simplified Chinese)`), with a graceful fallback to the bare code.
* Added a changeset (patch bump for `@lingo.dev/compiler`).

## Testing

**Business logic tests added:**

- [X] `shots.test.ts` — `getShots()` returns the example matching the target language and never a mismatched one: Spanish variants (`es`, `es-419`, `es-MX`) → Spanish; script-aware Chinese (`zh-Hans`/`zh-CN`/bare `zh` → Simplified, `zh-Hant`/`zh-TW` → Traditional); `ja`/`ko`/`fr-CA` → their language.
- [X] `shots.test.ts` — uncovered locales and the source language (`sw`, `hu`, `en`) return no example (regression guard against wrong-language drift), and each example keeps English input with output keys aligned to input.
- [X] `prompt.test.ts` — the built-in prompt names both languages (`en (English)`, `es (Spanish)`, `zh-Hans (Simplified Chinese)`), and the user-defined prompt path still substitutes `{SOURCE_LOCALE}` / `{TARGET_LOCALE}`.
- [X] All tests pass locally (`pnpm --filter @lingo.dev/compiler test` → 229 passed).

## Visuals

N/A — no UI/UX changes (compiler and prompt only).

## Checklist

- [X] Changeset added (patch bump for `@lingo.dev/compiler`)
- [X] Tests cover business logic (selector + prompt behavior, including edge cases, not just the happy path)
- [X] No breaking changes — the default `lingo.dev` engine path is untouched, existing caches are keyed by content hash (not the prompt) so nothing is re-translated, and Spanish targets keep the exact previous example.

Closes lingodotdev/lingo.dev#2041

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translations on cache misses potentially being primed with examples for the wrong target language.
  * Few-shot examples now match the requested locale, including Simplified and Traditional Chinese.
  * Unsupported target locales no longer receive potentially misleading examples.
* **Improvements**
  * Prompts now display readable source and target language names alongside locale codes.
  * Added coverage for Spanish, French, German, Italian, Portuguese, Dutch, Russian, Japanese, Korean, and Chinese locales.