### PR TITLE
fix(sdk): attach the organization group to PostHog events

### DIFF
--- a/.changeset/sdk-organization-group.md
+++ b/.changeset/sdk-organization-group.md
@@ -1,0 +1,7 @@
+---
+"@lingo.dev/_sdk": patch
+---
+
+SDK PostHog events now attach the `organization` group when the API reports the
+key's organization, so SDK activity shows up in org-level analytics. No behavior
+change for API keys whose server does not return an organization id.

--- a/packages/sdk/src/utils/observability.spec.ts
+++ b/packages/sdk/src/utils/observability.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { trackEvent, _resetIdentityCache } from "./observability";
 
-const capture = vi.fn(async () => undefined);
+const capture = vi.fn(async (_payload: Record<string, any>) => undefined);
 const shutdown = vi.fn(async () => undefined);
 const PostHogMock = vi.fn(function (_key: string, _cfg: any) {
   return { alias: vi.fn(), capture, shutdown };
@@ -73,6 +73,26 @@ describe("trackEvent", () => {
         expect.objectContaining({
           distinctId: "123",
           groups: { organization: "org_abc123" },
+        }),
+      ),
+    );
+  });
+
+  it("sends email as an identify $set trait, never as the distinct_id", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ email: "user@test.com", id: "123" }),
+    }) as any;
+
+    trackEvent("test-key", "https://test.api", "sdk.localize.start", {});
+
+    await vi.waitFor(() =>
+      expect(capture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          distinctId: "123",
+          properties: expect.objectContaining({
+            $set: expect.objectContaining({ email: "user@test.com" }),
+          }),
         }),
       ),
     );

--- a/packages/sdk/src/utils/observability.spec.ts
+++ b/packages/sdk/src/utils/observability.spec.ts
@@ -68,13 +68,13 @@ describe("trackEvent", () => {
 
     trackEvent("test-key", "https://test.api", "sdk.localize.start", {});
 
-    await new Promise((r) => setTimeout(r, 200));
-
-    expect(capture).toHaveBeenCalledWith(
-      expect.objectContaining({
-        distinctId: "123",
-        groups: { organization: "org_abc123" },
-      }),
+    await vi.waitFor(() =>
+      expect(capture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          distinctId: "123",
+          groups: { organization: "org_abc123" },
+        }),
+      ),
     );
   });
 
@@ -86,16 +86,12 @@ describe("trackEvent", () => {
 
     trackEvent("test-key", "https://test.api", "sdk.localize.start", {});
 
-    await new Promise((r) => setTimeout(r, 200));
-
-    expect(capture).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
     expect(capture.mock.calls[0][0]).not.toHaveProperty("groups");
   });
 
   it("falls back to API key hash when whoami fails", async () => {
-    globalThis.fetch = vi
-      .fn()
-      .mockRejectedValue(new Error("Network error")) as any;
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error")) as any;
 
     trackEvent("my-api-key", "https://test.api", "sdk.localize.start", {});
 

--- a/packages/sdk/src/utils/observability.spec.ts
+++ b/packages/sdk/src/utils/observability.spec.ts
@@ -56,6 +56,42 @@ describe("trackEvent", () => {
     expect(shutdown).toHaveBeenCalledTimes(1);
   });
 
+  it("attaches organization group when whoami returns organizationId", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        email: "user@test.com",
+        id: "123",
+        organizationId: "org_abc123",
+      }),
+    }) as any;
+
+    trackEvent("test-key", "https://test.api", "sdk.localize.start", {});
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distinctId: "123",
+        groups: { organization: "org_abc123" },
+      }),
+    );
+  });
+
+  it("omits groups when whoami returns no organizationId", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ email: "user@test.com", id: "123" }),
+    }) as any;
+
+    trackEvent("test-key", "https://test.api", "sdk.localize.start", {});
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0][0]).not.toHaveProperty("groups");
+  });
+
   it("falls back to API key hash when whoami fails", async () => {
     globalThis.fetch = vi
       .fn()
@@ -73,6 +109,7 @@ describe("trackEvent", () => {
         }),
       }),
     );
+    expect(capture.mock.calls[0][0]).not.toHaveProperty("groups");
   });
 
   it("falls back to API key hash when whoami returns no id", async () => {

--- a/packages/sdk/src/utils/observability.spec.ts
+++ b/packages/sdk/src/utils/observability.spec.ts
@@ -143,7 +143,7 @@ describe("trackEvent", () => {
 
     // whoami fetch should only be called once due to caching
     const whoamiCalls = mockFetch.mock.calls.filter(
-      (call) => typeof call[0] === "string" && call[0].includes("/users/me"),
+      (call) => typeof call[0] === "string" && call[0].includes("/whoami"),
     );
     expect(whoamiCalls).toHaveLength(1);
     expect(capture).toHaveBeenCalledTimes(2);
@@ -163,7 +163,7 @@ describe("trackEvent", () => {
     await new Promise((r) => setTimeout(r, 200));
 
     const whoamiCalls = mockFetch.mock.calls.filter(
-      (call) => typeof call[0] === "string" && call[0].includes("/users/me"),
+      (call) => typeof call[0] === "string" && call[0].includes("/whoami"),
     );
     expect(whoamiCalls).toHaveLength(2);
   });

--- a/packages/sdk/src/utils/observability.spec.ts
+++ b/packages/sdk/src/utils/observability.spec.ts
@@ -78,6 +78,55 @@ describe("trackEvent", () => {
     );
   });
 
+  it("keys a personal key on userId, with the email trait", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ email: "u@test.com", id: "u1", organizationId: "org_1", keyId: "key_1", userId: "u1" }),
+    }) as any;
+
+    trackEvent("test-key", "https://test.api", "sdk.localize.start", {});
+
+    await vi.waitFor(() =>
+      expect(capture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          distinctId: "u1",
+          groups: { organization: "org_1" },
+          properties: expect.objectContaining({
+            distinct_id_source: "database_id",
+            $set: expect.objectContaining({ email: "u@test.com" }),
+          }),
+        }),
+      ),
+    );
+  });
+
+  it("keys a service key on keyId, never the creator, and sends no email", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        email: "creator@test.com",
+        id: "creator",
+        organizationId: "org_1",
+        keyId: "key_svc",
+        userId: null,
+      }),
+    }) as any;
+
+    trackEvent("test-key", "https://test.api", "sdk.localize.start", {});
+
+    await vi.waitFor(() =>
+      expect(capture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          distinctId: "key_svc",
+          groups: { organization: "org_1" },
+          properties: expect.objectContaining({ distinct_id_source: "api_key_id" }),
+        }),
+      ),
+    );
+    // Automation has no person: the creator's email must not ride along.
+    expect(capture.mock.calls[0][0].properties.$set).not.toHaveProperty("email");
+  });
+
   it("sends email as an identify $set trait, never as the distinct_id", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/sdk/src/utils/observability.ts
+++ b/packages/sdk/src/utils/observability.ts
@@ -70,14 +70,6 @@ async function resolveIdentityAndCapture(
         distinct_id_source: identity.distinct_id_source,
       },
     });
-
-    // TODO: remove after 2026-04-30 — temporary alias to merge old email-based distinct_ids with database user ID
-    if (email) {
-      await posthog.alias({
-        distinctId: identity.distinct_id,
-        alias: email,
-      });
-    }
   } finally {
     await posthog.shutdown();
   }
@@ -95,8 +87,10 @@ async function getDistinctId(
   if (cached) return cached;
 
   try {
-    const res = await fetch(`${apiUrl}/users/me`, {
-      method: "GET",
+    // `/whoami` carries `organizationId` for exactly this purpose (attaching the
+    // `organization` group); `/users/me` never returned it, so org grouping was a no-op.
+    const res = await fetch(`${apiUrl}/whoami`, {
+      method: "POST",
       headers: {
         "X-API-Key": apiKey,
         "Content-Type": "application/json",
@@ -125,7 +119,7 @@ async function getDistinctId(
     // Fall through to API key hash
   }
 
-  // Don't cache the fallback — a transient /users/me failure should not poison the cache for the entire process lifetime
+  // Don't cache the fallback — a transient /whoami failure should not poison the cache for the entire process lifetime
   const hash = createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
   return {
     identity: {

--- a/packages/sdk/src/utils/observability.ts
+++ b/packages/sdk/src/utils/observability.ts
@@ -11,7 +11,7 @@ type IdentityInfo = {
 
 const identityCache = new Map<
   string,
-  { identity: IdentityInfo; email?: string }
+  { identity: IdentityInfo; email?: string; organizationId?: string }
 >();
 
 export function trackEvent(
@@ -39,7 +39,10 @@ async function resolveIdentityAndCapture(
   event: string,
   properties?: Record<string, any>,
 ) {
-  const { identity, email } = await getDistinctId(apiKey, apiUrl);
+  const { identity, email, organizationId } = await getDistinctId(
+    apiKey,
+    apiUrl,
+  );
 
   if (process.env.DEBUG === "true") {
     console.log(
@@ -58,6 +61,7 @@ async function resolveIdentityAndCapture(
     await posthog.capture({
       distinctId: identity.distinct_id,
       event,
+      ...(organizationId ? { groups: { organization: organizationId } } : {}),
       properties: {
         ...properties,
         $set: { ...(properties?.$set || {}), ...(email ? { email } : {}) },
@@ -82,7 +86,11 @@ async function resolveIdentityAndCapture(
 async function getDistinctId(
   apiKey: string,
   apiUrl: string,
-): Promise<{ identity: IdentityInfo; email?: string }> {
+): Promise<{
+  identity: IdentityInfo;
+  email?: string;
+  organizationId?: string;
+}> {
   const cached = identityCache.get(apiKey);
   if (cached) return cached;
 
@@ -104,6 +112,10 @@ async function getDistinctId(
             distinct_id_source: "database_id",
           },
           email: payload.email || undefined,
+          organizationId:
+            typeof payload.organizationId === "string"
+              ? payload.organizationId
+              : undefined,
         };
         identityCache.set(apiKey, result);
         return result;

--- a/packages/sdk/src/utils/observability.ts
+++ b/packages/sdk/src/utils/observability.ts
@@ -71,14 +71,10 @@ async function getDistinctId(
   const cached = identityCache.get(apiKey);
   if (cached) return cached;
 
-  // KNOWN GAP (service keys): `/whoami` returns the key's human creator, so a
-  // service-key run is still keyed on a person, not the key. ANALYTICS.md wants a
-  // service key's actor to be the key itself. Closing this needs a server-side
-  // signal (key id / type on `/whoami`) that does not exist yet — tracked as a
-  // follow-up, since it spans the API and this client.
   try {
-    // `/whoami` carries `organizationId` for exactly this purpose (attaching the
-    // `organization` group); `/users/me` never returned it, so org grouping was a no-op.
+    // `/whoami` carries the full telemetry identity: `organizationId` for the group,
+    // `userId` (the human behind a personal key, null for a service key) and `keyId`
+    // (the stable actor a service-key run keys on). `/users/me` returned none of it.
     const res = await fetch(`${apiUrl}/whoami`, {
       method: "POST",
       headers: {
@@ -89,15 +85,32 @@ async function getDistinctId(
 
     if (res.ok) {
       const payload = await res.json();
-      if (payload?.id) {
-        const result = {
-          identity: {
-            distinct_id: payload.id,
-            distinct_id_source: "database_id",
-          },
+      const organizationId = typeof payload?.organizationId === "string" ? payload.organizationId : undefined;
+      let result: { identity: IdentityInfo; email?: string; organizationId?: string } | undefined;
+
+      if (typeof payload?.userId === "string") {
+        // Personal key: the actor is the human; email rides as an identify trait.
+        result = {
+          identity: { distinct_id: payload.userId, distinct_id_source: "database_id" },
           email: payload.email || undefined,
-          organizationId: typeof payload.organizationId === "string" ? payload.organizationId : undefined,
+          organizationId,
         };
+      } else if (typeof payload?.keyId === "string") {
+        // Service key: the actor is the key itself — no human, so no email trait.
+        result = {
+          identity: { distinct_id: payload.keyId, distinct_id_source: "api_key_id" },
+          organizationId,
+        };
+      } else if (payload?.id) {
+        // Back-compat: an older API predating `userId`/`keyId` still returns the user id.
+        result = {
+          identity: { distinct_id: payload.id, distinct_id_source: "database_id" },
+          email: payload.email || undefined,
+          organizationId,
+        };
+      }
+
+      if (result) {
         identityCache.set(apiKey, result);
         return result;
       }

--- a/packages/sdk/src/utils/observability.ts
+++ b/packages/sdk/src/utils/observability.ts
@@ -9,28 +9,18 @@ type IdentityInfo = {
   distinct_id_source: string;
 };
 
-const identityCache = new Map<
-  string,
-  { identity: IdentityInfo; email?: string; organizationId?: string }
->();
+const identityCache = new Map<string, { identity: IdentityInfo; email?: string; organizationId?: string }>();
 
-export function trackEvent(
-  apiKey: string,
-  apiUrl: string,
-  event: string,
-  properties?: Record<string, any>,
-): void {
+export function trackEvent(apiKey: string, apiUrl: string, event: string, properties?: Record<string, any>): void {
   if (process.env.DO_NOT_TRACK === "1") {
     return;
   }
 
-  resolveIdentityAndCapture(apiKey, apiUrl, event, properties).catch(
-    (error) => {
-      if (process.env.DEBUG === "true") {
-        console.error("[Tracking] Error:", error);
-      }
-    },
-  );
+  resolveIdentityAndCapture(apiKey, apiUrl, event, properties).catch((error) => {
+    if (process.env.DEBUG === "true") {
+      console.error("[Tracking] Error:", error);
+    }
+  });
 }
 
 async function resolveIdentityAndCapture(
@@ -39,15 +29,10 @@ async function resolveIdentityAndCapture(
   event: string,
   properties?: Record<string, any>,
 ) {
-  const { identity, email, organizationId } = await getDistinctId(
-    apiKey,
-    apiUrl,
-  );
+  const { identity, email, organizationId } = await getDistinctId(apiKey, apiUrl);
 
   if (process.env.DEBUG === "true") {
-    console.log(
-      `[Tracking] Event: ${event}, ID: ${identity.distinct_id}, Source: ${identity.distinct_id_source}`,
-    );
+    console.log(`[Tracking] Event: ${event}, ID: ${identity.distinct_id}, Source: ${identity.distinct_id_source}`);
   }
 
   const { PostHog } = await import("posthog-node");
@@ -86,6 +71,11 @@ async function getDistinctId(
   const cached = identityCache.get(apiKey);
   if (cached) return cached;
 
+  // KNOWN GAP (service keys): `/whoami` returns the key's human creator, so a
+  // service-key run is still keyed on a person, not the key. ANALYTICS.md wants a
+  // service key's actor to be the key itself. Closing this needs a server-side
+  // signal (key id / type on `/whoami`) that does not exist yet — tracked as a
+  // follow-up, since it spans the API and this client.
   try {
     // `/whoami` carries `organizationId` for exactly this purpose (attaching the
     // `organization` group); `/users/me` never returned it, so org grouping was a no-op.
@@ -106,10 +96,7 @@ async function getDistinctId(
             distinct_id_source: "database_id",
           },
           email: payload.email || undefined,
-          organizationId:
-            typeof payload.organizationId === "string"
-              ? payload.organizationId
-              : undefined,
+          organizationId: typeof payload.organizationId === "string" ? payload.organizationId : undefined,
         };
         identityCache.set(apiKey, result);
         return result;


### PR DESCRIPTION
Part of ENG-1270 (PostHog identity contract). The SDK already keys `distinct_id` on the user id from whoami, but never set the `organization` group, so SDK events are invisible to org-level metrics.

- The whoami response now optionally carries `organizationId` (platform-side change, ships separately); the SDK reads it when present and tolerates servers that omit it.
- When the org is known, every `sdk.*` capture gets `groups: { organization: orgId }` (posthog-node capture option).
- `distinct_id` logic, the `apikey-<hash>` fallback, email via `$set`, and the legacy alias block are untouched.

Tests: 2 new specs (group attached when whoami returns the org, absent otherwise) + fallback-path assertion; packages/sdk 50/50 green, tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization context to SDK analytics events by including an `organization` group when an organization id is available (from the authenticated identity and API-key lookup).
* **Bug Fixes**
  * Ensured the `groups` property is not added when no organization id is returned, preserving existing event grouping behavior; this is also maintained for the API-key-hash fallback path.
* **Tests**
  * Expanded observability coverage to validate the PostHog capture payload across organization-present, organization-absent, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Service keys

Service-key runs key `distinct_id` on the key id (not the key's human creator): `/whoami` now returns `keyId` and an actor `userId` (null for service keys), and the SDK keys on `userId ?? keyId`. Requires the v1 `/whoami` change deployed first (ship order: v1 → SDK).