### PR TITLE
fix(compiler): keep translations that completed before a run failed

### DIFF
--- a/.changeset/persist-completed-translations.md
+++ b/.changeset/persist-completed-translations.md
@@ -1,0 +1,15 @@
+---
+"@lingo.dev/compiler": patch
+---
+
+Keep translations that completed before a run failed.
+
+When a translation run threw partway through, every entry that had already come back was
+discarded: the cache write sits after an early `return` in the `catch`, and the chunk loop
+had no inner `try`, so a failure on one chunk took the earlier chunks with it. Those entries
+were already generated and billed, and because the next build derives its work list from
+what is missing from the cache, the identical strings were submitted and paid for again on
+every subsequent build.
+
+Failed runs now persist what completed. The failure is still reported and the build still
+fails, so the only change in behaviour is that already-paid work survives.

--- a/packages/new-compiler/src/translators/api.ts
+++ b/packages/new-compiler/src/translators/api.ts
@@ -12,18 +12,17 @@ export interface Translator<Config> {
 }
 
 /**
- * Thrown when a translation run fails partway through.
- *
- * Carries the entries that already came back so the caller can persist them.
- * Those entries have been paid for; discarding them makes the next build
- * request and pay for identical source text again.
+ * Thrown when a translation run fails partway through, carrying the entries
+ * that already came back. They have been paid for, so discarding them makes the
+ * next build request and pay for identical source text again.
  */
 export class PartialTranslationError extends Error {
   constructor(
-    readonly partialTranslations: Record<string, string>,
-    override readonly cause: unknown,
+    message: string,
+    public readonly partialTranslations: Record<string, string>,
+    cause: unknown,
   ) {
-    super(cause instanceof Error ? cause.message : String(cause));
+    super(message, { cause });
     this.name = "PartialTranslationError";
   }
 }

--- a/packages/new-compiler/src/translators/api.ts
+++ b/packages/new-compiler/src/translators/api.ts
@@ -12,6 +12,23 @@ export interface Translator<Config> {
 }
 
 /**
+ * Thrown when a translation run fails partway through.
+ *
+ * Carries the entries that already came back so the caller can persist them.
+ * Those entries have been paid for; discarding them makes the next build
+ * request and pay for identical source text again.
+ */
+export class PartialTranslationError extends Error {
+  constructor(
+    readonly partialTranslations: Record<string, string>,
+    override readonly cause: unknown,
+  ) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "PartialTranslationError";
+  }
+}
+
+/**
  * Dictionary schema for translation
  * Simple flat structure with direct access to translations
  */

--- a/packages/new-compiler/src/translators/lingo/timeout-repro.test.ts
+++ b/packages/new-compiler/src/translators/lingo/timeout-repro.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PartialTranslationError } from "../api";
+import { Logger } from "../../utils/logger";
+
+const localizeObject = vi.fn();
+
+vi.mock("lingo.dev/sdk", () => ({
+  LingoDotDevEngine: class {
+    localizeObject = localizeObject;
+  },
+}));
+
+vi.mock("./model-factory", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./model-factory")>()),
+  validateAndGetApiKeys: () => ({ "lingo.dev": "test-key" }),
+}));
+
+const { LingoTranslator } = await import("./translator");
+
+function sourceEntries(count: number) {
+  return Object.fromEntries(
+    Array.from({ length: count }, (_, i) => [
+      `h${i}`,
+      { text: `text ${i}`, context: {} },
+    ]),
+  );
+}
+
+describe("the reported failure: a chunk exceeds the 60s API timeout", () => {
+  it("should keep the chunks that finished, and not re-request them next run", async () => {
+    vi.useFakeTimers();
+
+    // Chunks 1 and 2 come back; chunk 3 hangs, which is what the 60s
+    // DEFAULT_TIMEOUTS.AI_API ceiling turns into a TimeoutError.
+    localizeObject
+      .mockImplementationOnce(async (dictionary) => translated(dictionary))
+      .mockImplementationOnce(async (dictionary) => translated(dictionary))
+      .mockImplementationOnce(() => new Promise(() => {}));
+
+    const translator = new LingoTranslator(
+      { models: "lingo.dev", sourceLocale: "en" },
+      new Logger({ enableConsole: false }),
+    );
+
+    const run = translator
+      .translate("de", sourceEntries(250))
+      .catch((caught: unknown) => caught);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    const error = await run;
+
+    vi.useRealTimers();
+
+    expect(error).toBeInstanceOf(PartialTranslationError);
+    expect((error as Error).message).toContain("timed out after 60000ms");
+
+    const partial = (error as PartialTranslationError).partialTranslations;
+    expect(Object.keys(partial)).toHaveLength(200);
+    expect(partial.h0).toBe("h0-de");
+    expect(partial.h199).toBe("h199-de");
+    expect(partial.h200).toBeUndefined();
+  });
+});
+
+function translated(dictionary: { entries: Record<string, string> }) {
+  return {
+    ...dictionary,
+    locale: "de",
+    entries: Object.fromEntries(
+      Object.keys(dictionary.entries).map((hash) => [hash, `${hash}-de`]),
+    ),
+  };
+}

--- a/packages/new-compiler/src/translators/lingo/timeout-repro.test.ts
+++ b/packages/new-compiler/src/translators/lingo/timeout-repro.test.ts
@@ -28,7 +28,7 @@ function sourceEntries(count: number) {
 }
 
 describe("the reported failure: a chunk exceeds the 60s API timeout", () => {
-  it("should keep the chunks that finished, and not re-request them next run", async () => {
+  it("should keep the chunks that finished before the timeout", async () => {
     vi.useFakeTimers();
 
     // Chunks 1 and 2 come back; chunk 3 hangs, which is what the 60s

--- a/packages/new-compiler/src/translators/lingo/translator.test.ts
+++ b/packages/new-compiler/src/translators/lingo/translator.test.ts
@@ -4,6 +4,14 @@ import { PartialTranslationError, type DictionarySchema } from "../api";
 import { LingoTranslator } from "./translator";
 import { Logger } from "../../utils/logger";
 
+vi.mock("lingo.dev/sdk", () => ({
+  LingoDotDevEngine: class {
+    localizeObject = () => {
+      throw new Error("the SDK must not be reached from this test");
+    };
+  },
+}));
+
 vi.mock("./model-factory", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./model-factory")>()),
   validateAndGetApiKeys: () => ({ "lingo.dev": "test-key" }),
@@ -14,9 +22,6 @@ type TranslateChunkFn = (
   targetLocale: string,
 ) => Promise<DictionarySchema>;
 
-// `translateChunk` is the seam: stubbing it exercises the real chunking and
-// merging without reaching the network. The cast names the member so a rename
-// fails to compile rather than silently calling the real engine.
 function makeTranslator(translateChunk: TranslateChunkFn) {
   const translator = new LingoTranslator(
     { models: "lingo.dev", sourceLocale: "en" },

--- a/packages/new-compiler/src/translators/lingo/translator.test.ts
+++ b/packages/new-compiler/src/translators/lingo/translator.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LocaleCode } from "lingo.dev/spec";
+
+import { PartialTranslationError, type DictionarySchema } from "../api";
+import { LingoTranslator } from "./translator";
+import type { Logger } from "../../utils/logger";
+
+vi.mock("./model-factory", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./model-factory")>()),
+  validateAndGetApiKeys: () => ({ "lingo.dev": "test-key" }),
+}));
+
+const silentLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as Logger;
+
+// One chunk is 100 entries, so 250 entries is three chunks.
+function entriesOf(count: number, offset = 0) {
+  return Object.fromEntries(Array.from({ length: count }, (_, i) => [`h${offset + i}`, `text ${offset + i}`]));
+}
+
+function makeTranslator(translateChunk: (chunk: DictionarySchema) => Promise<DictionarySchema>) {
+  const translator = new LingoTranslator({ models: "lingo.dev", sourceLocale: "en" as LocaleCode }, silentLogger);
+
+  Object.assign(translator as never, { translateChunk });
+
+  return translator;
+}
+
+describe("LingoTranslator.translate when a chunk fails", () => {
+  it("hands back the chunks that completed before the failure", async () => {
+    let call = 0;
+    const translator = makeTranslator(async (chunk) => {
+      call += 1;
+      if (call === 3) throw new Error("Lingo.dev API translation to de timed out after 60000ms");
+      return {
+        version: chunk.version,
+        locale: "de" as LocaleCode,
+        entries: Object.fromEntries(Object.keys(chunk.entries).map((hash) => [hash, `${hash}-de`])),
+      };
+    });
+
+    const entries = Object.fromEntries(
+      Object.entries(entriesOf(250)).map(([hash, text]) => [hash, { text, context: {} }]),
+    );
+
+    const error = await translator.translate("de" as LocaleCode, entries).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PartialTranslationError);
+    const partial = (error as PartialTranslationError).partialTranslations;
+    expect(Object.keys(partial)).toHaveLength(200);
+    expect(partial.h0).toBe("h0-de");
+    expect(partial.h199).toBe("h199-de");
+    expect(partial.h200).toBeUndefined();
+  });
+
+  it("keeps the original error reachable as the cause", async () => {
+    const cause = new Error("timed out after 60000ms");
+    const translator = makeTranslator(async () => {
+      throw cause;
+    });
+
+    const error = await translator
+      .translate("de" as LocaleCode, { h0: { text: "text", context: {} } })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PartialTranslationError);
+    expect((error as PartialTranslationError).cause).toBe(cause);
+    expect((error as PartialTranslationError).partialTranslations).toEqual({});
+  });
+});

--- a/packages/new-compiler/src/translators/lingo/translator.test.ts
+++ b/packages/new-compiler/src/translators/lingo/translator.test.ts
@@ -1,53 +1,64 @@
 import { describe, expect, it, vi } from "vitest";
-import type { LocaleCode } from "lingo.dev/spec";
 
 import { PartialTranslationError, type DictionarySchema } from "../api";
 import { LingoTranslator } from "./translator";
-import type { Logger } from "../../utils/logger";
+import { Logger } from "../../utils/logger";
 
 vi.mock("./model-factory", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./model-factory")>()),
   validateAndGetApiKeys: () => ({ "lingo.dev": "test-key" }),
 }));
 
-const silentLogger = {
-  debug: vi.fn(),
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-} as unknown as Logger;
+type TranslateChunkFn = (
+  chunk: DictionarySchema,
+  targetLocale: string,
+) => Promise<DictionarySchema>;
 
-// One chunk is 100 entries, so 250 entries is three chunks.
-function entriesOf(count: number, offset = 0) {
-  return Object.fromEntries(Array.from({ length: count }, (_, i) => [`h${offset + i}`, `text ${offset + i}`]));
-}
+// `translateChunk` is the seam: stubbing it exercises the real chunking and
+// merging without reaching the network. The cast names the member so a rename
+// fails to compile rather than silently calling the real engine.
+function makeTranslator(translateChunk: TranslateChunkFn) {
+  const translator = new LingoTranslator(
+    { models: "lingo.dev", sourceLocale: "en" },
+    new Logger({ enableConsole: false }),
+  );
 
-function makeTranslator(translateChunk: (chunk: DictionarySchema) => Promise<DictionarySchema>) {
-  const translator = new LingoTranslator({ models: "lingo.dev", sourceLocale: "en" as LocaleCode }, silentLogger);
-
-  Object.assign(translator as never, { translateChunk });
+  Object.assign(translator as unknown as { translateChunk: TranslateChunkFn }, {
+    translateChunk,
+  });
 
   return translator;
 }
 
+function sourceEntries(count: number) {
+  return Object.fromEntries(
+    Array.from({ length: count }, (_, i) => [
+      `h${i}`,
+      { text: `text ${i}`, context: {} },
+    ]),
+  );
+}
+
 describe("LingoTranslator.translate when a chunk fails", () => {
-  it("hands back the chunks that completed before the failure", async () => {
+  it("should hand back the chunks that completed before the failure", async () => {
+    // MAX_ENTRIES_PER_CHUNK is 100, so 250 entries is three chunks and
+    // failing the third leaves the first two, i.e. 200 entries.
     let call = 0;
     const translator = makeTranslator(async (chunk) => {
       call += 1;
-      if (call === 3) throw new Error("Lingo.dev API translation to de timed out after 60000ms");
+      if (call === 3) throw new Error("timed out after 60000ms");
       return {
         version: chunk.version,
-        locale: "de" as LocaleCode,
-        entries: Object.fromEntries(Object.keys(chunk.entries).map((hash) => [hash, `${hash}-de`])),
+        locale: "de",
+        entries: Object.fromEntries(
+          Object.keys(chunk.entries).map((hash) => [hash, `${hash}-de`]),
+        ),
       };
     });
 
-    const entries = Object.fromEntries(
-      Object.entries(entriesOf(250)).map(([hash, text]) => [hash, { text, context: {} }]),
-    );
-
-    const error = await translator.translate("de" as LocaleCode, entries).catch((caught: unknown) => caught);
+    const error = await translator
+      .translate("de", sourceEntries(250))
+      .catch((caught: unknown) => caught);
 
     expect(error).toBeInstanceOf(PartialTranslationError);
     const partial = (error as PartialTranslationError).partialTranslations;
@@ -57,14 +68,14 @@ describe("LingoTranslator.translate when a chunk fails", () => {
     expect(partial.h200).toBeUndefined();
   });
 
-  it("keeps the original error reachable as the cause", async () => {
+  it("should keep the original error reachable as the cause", async () => {
     const cause = new Error("timed out after 60000ms");
     const translator = makeTranslator(async () => {
       throw cause;
     });
 
     const error = await translator
-      .translate("de" as LocaleCode, { h0: { text: "text", context: {} } })
+      .translate("de", sourceEntries(1))
       .catch((caught: unknown) => caught);
 
     expect(error).toBeInstanceOf(PartialTranslationError);

--- a/packages/new-compiler/src/translators/lingo/translator.ts
+++ b/packages/new-compiler/src/translators/lingo/translator.ts
@@ -75,20 +75,20 @@ export class LingoTranslator implements Translator<LingoTranslatorConfig> {
 
     try {
       for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
-      this.logger.debug(
-        `Translating chunk ${i + 1}/${chunks.length} with ${Object.keys(chunk.entries).length} entries`,
-      );
-      const chunkStartTime = performance.now();
+        const chunk = chunks[i];
+        this.logger.debug(
+          `Translating chunk ${i + 1}/${chunks.length} with ${Object.keys(chunk.entries).length} entries`,
+        );
+        const chunkStartTime = performance.now();
 
-      const translatedChunk = await this.translateChunk(chunk, targetLocale);
+        const translatedChunk = await this.translateChunk(chunk, targetLocale);
 
-      const chunkEndTime = performance.now();
-      this.logger.debug(
-        `Chunk ${i + 1}/${chunks.length} completed in ${(chunkEndTime - chunkStartTime).toFixed(2)}ms`,
-      );
+        const chunkEndTime = performance.now();
+        this.logger.debug(
+          `Chunk ${i + 1}/${chunks.length} completed in ${(chunkEndTime - chunkStartTime).toFixed(2)}ms`,
+        );
 
-      translatedChunks.push(translatedChunk);
+        translatedChunks.push(translatedChunk);
       }
     } catch (error) {
       throw new PartialTranslationError(

--- a/packages/new-compiler/src/translators/lingo/translator.ts
+++ b/packages/new-compiler/src/translators/lingo/translator.ts
@@ -73,19 +73,15 @@ export class LingoTranslator implements Translator<LingoTranslatorConfig> {
 
     const translatedChunks: DictionarySchema[] = [];
 
-    for (let i = 0; i < chunks.length; i++) {
+    try {
+      for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
       this.logger.debug(
         `Translating chunk ${i + 1}/${chunks.length} with ${Object.keys(chunk.entries).length} entries`,
       );
       const chunkStartTime = performance.now();
 
-      let translatedChunk: DictionarySchema;
-      try {
-        translatedChunk = await this.translateChunk(chunk, targetLocale);
-      } catch (error) {
-        throw new PartialTranslationError(this.mergeDictionaries(translatedChunks).entries, error);
-      }
+      const translatedChunk = await this.translateChunk(chunk, targetLocale);
 
       const chunkEndTime = performance.now();
       this.logger.debug(
@@ -93,6 +89,13 @@ export class LingoTranslator implements Translator<LingoTranslatorConfig> {
       );
 
       translatedChunks.push(translatedChunk);
+      }
+    } catch (error) {
+      throw new PartialTranslationError(
+        error instanceof Error ? error.message : String(error),
+        this.mergeDictionaries(translatedChunks).entries,
+        error,
+      );
     }
 
     const result = this.mergeDictionaries(translatedChunks);

--- a/packages/new-compiler/src/translators/lingo/translator.ts
+++ b/packages/new-compiler/src/translators/lingo/translator.ts
@@ -1,6 +1,6 @@
 import { generateText } from "ai";
 import { LingoDotDevEngine } from "lingo.dev/sdk";
-import { dictionaryFrom, type DictionarySchema, type TranslatableEntry, type Translator, } from "../api";
+import { dictionaryFrom, PartialTranslationError, type DictionarySchema, type TranslatableEntry, type Translator, } from "../api";
 import { getSystemPrompt } from "./prompt";
 import { obj2xml, parseXmlFromResponseText } from "../parse-xml";
 import { shots } from "./shots";
@@ -80,7 +80,12 @@ export class LingoTranslator implements Translator<LingoTranslatorConfig> {
       );
       const chunkStartTime = performance.now();
 
-      const translatedChunk = await this.translateChunk(chunk, targetLocale);
+      let translatedChunk: DictionarySchema;
+      try {
+        translatedChunk = await this.translateChunk(chunk, targetLocale);
+      } catch (error) {
+        throw new PartialTranslationError(this.mergeDictionaries(translatedChunks).entries, error);
+      }
 
       const chunkEndTime = performance.now();
       this.logger.debug(

--- a/packages/new-compiler/src/translators/translation-service.test.ts
+++ b/packages/new-compiler/src/translators/translation-service.test.ts
@@ -1,116 +1,134 @@
 import { describe, expect, it, vi } from "vitest";
-import type { LocaleCode } from "lingo.dev/spec";
 
-import { PartialTranslationError, type TranslatableEntry } from "./api";
+import { PartialTranslationError, type Translator } from "./api";
 import { TranslationService } from "./translation-service";
 import { MemoryTranslationCache } from "./memory-cache";
+import type { TranslationCache } from "./cache";
 import type { MetadataSchema } from "../types";
-import type { Logger } from "../utils/logger";
+import { Logger } from "../utils/logger";
 
-const silentLogger = {
-  debug: vi.fn(),
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-} as unknown as Logger;
-
-type TranslateFn = (locale: LocaleCode, entries: Record<string, TranslatableEntry>) => Promise<Record<string, string>>;
+type TranslateFn = Translator<unknown>["translate"];
 
 function metadataOf(entries: Record<string, string>): MetadataSchema {
   return Object.fromEntries(
-    Object.entries(entries).map(([hash, sourceText]) => [hash, { sourceText, context: {} }]),
+    Object.entries(entries).map(([hash, sourceText]) => [
+      hash,
+      {
+        type: "content",
+        hash,
+        sourceText,
+        context: { filePath: "src/App.tsx" },
+        location: { filePath: "src/App.tsx", line: 1, column: 1 },
+      },
+    ]),
   ) as MetadataSchema;
 }
 
-// The service builds its own translator and cache, so there is no constructor
-// seam. Take the pseudotranslator path, which needs no API keys, then swap both
-// collaborators for controllable ones.
+// TranslationService builds its own translator and cache, so there is no
+// constructor seam. Take the pseudotranslator branch, which needs no API keys,
+// then swap both collaborators. The cast names the members so a rename fails to
+// compile rather than silently leaving the real translator wired in.
 function makeService(translate: TranslateFn) {
   const service = new TranslationService(
     {
-      sourceLocale: "en" as LocaleCode,
-      pluralization: { enabled: false },
+      sourceLocale: "en",
+      sourceRoot: "src",
+      lingoDir: "lingo",
+      cacheType: "local",
+      pluralization: { enabled: false, model: "groq:llama3-8b-8192" },
       models: "lingo.dev",
       environment: "development",
       dev: { usePseudotranslator: true },
-      cacheDir: "/tmp/lingo-test-cache-unused",
-    } as never,
-    silentLogger,
+    },
+    new Logger({ enableConsole: false }),
   );
 
   const cache = new MemoryTranslationCache();
-  Object.assign(service as never, {
-    translator: { config: {}, translate },
-    cache,
-  });
+  Object.assign(
+    service as unknown as {
+      translator: Translator<unknown>;
+      cache: TranslationCache;
+    },
+    { translator: { config: {}, translate }, cache },
+  );
 
   return { service, cache };
 }
 
 describe("TranslationService.translate on a failed run", () => {
-  it("caches the entries the translator finished before it failed, because they were already billed", async () => {
+  it("should cache the entries the translator finished before it failed", async () => {
     const { service, cache } = makeService(async () => {
       throw new PartialTranslationError(
+        "Lingo.dev API translation to de timed out after 60000ms",
         { a: "Alpha-de", b: "Bravo-de" },
-        new Error("Lingo.dev API translation to de timed out after 60000ms"),
+        new Error("timed out"),
       );
     });
 
-    const result = await service.translate("de" as LocaleCode, metadataOf({ a: "Alpha", b: "Bravo", c: "Charlie" }));
+    const result = await service.translate(
+      "de",
+      metadataOf({ a: "Alpha", b: "Bravo", c: "Charlie" }),
+    );
 
-    expect(await cache.get("de" as LocaleCode)).toEqual({
-      a: "Alpha-de",
-      b: "Bravo-de",
-    });
+    expect(await cache.get("de")).toEqual({ a: "Alpha-de", b: "Bravo-de" });
     expect(result.translations).toMatchObject({
       a: "Alpha-de",
       b: "Bravo-de",
     });
   });
 
-  it("still reports the failure so the build does not go green", async () => {
+  it("should still report the failure so the build does not go green", async () => {
     const { service } = makeService(async () => {
-      throw new PartialTranslationError({ a: "Alpha-de" }, new Error("boom"));
+      throw new PartialTranslationError("boom", { a: "Alpha-de" }, undefined);
     });
 
-    const result = await service.translate("de" as LocaleCode, metadataOf({ a: "Alpha", b: "Bravo" }));
+    const result = await service.translate(
+      "de",
+      metadataOf({ a: "Alpha", b: "Bravo" }),
+    );
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toMatchObject({ hash: "all" });
     expect(result.stats.failed).toBe(1);
   });
 
-  it("caches nothing when the run fails before any entry completes", async () => {
+  it("should cache nothing when the run fails before any entry completes", async () => {
     const { service, cache } = makeService(async () => {
-      throw new PartialTranslationError({}, new Error("boom"));
+      throw new PartialTranslationError("boom", {}, undefined);
     });
 
-    await service.translate("de" as LocaleCode, metadataOf({ a: "Alpha" }));
+    await service.translate("de", metadataOf({ a: "Alpha" }));
 
-    expect(await cache.get("de" as LocaleCode)).toEqual({});
+    expect(await cache.get("de")).toEqual({});
   });
 
-  it("survives a plain error that carries no partial results", async () => {
+  it("should survive a plain error that carries no partial results", async () => {
     const { service, cache } = makeService(async () => {
       throw new Error("network down");
     });
 
-    const result = await service.translate("de" as LocaleCode, metadataOf({ a: "Alpha" }));
+    const result = await service.translate("de", metadataOf({ a: "Alpha" }));
 
-    expect(await cache.get("de" as LocaleCode)).toEqual({});
+    expect(await cache.get("de")).toEqual({});
     expect(result.errors).toHaveLength(1);
   });
 
-  it("does not re-request what the failed run already cached", async () => {
+  it("should not re-request what the failed run already cached", async () => {
     const translate = vi
       .fn<TranslateFn>()
-      .mockRejectedValueOnce(new PartialTranslationError({ a: "Alpha-de" }, new Error("timeout")))
+      .mockRejectedValueOnce(
+        new PartialTranslationError(
+          "timeout",
+          { a: "Alpha-de" },
+          new Error("timed out"),
+        ),
+      )
       .mockResolvedValueOnce({ b: "Bravo-de" });
     const { service } = makeService(translate);
     const metadata = metadataOf({ a: "Alpha", b: "Bravo" });
 
-    await service.translate("de" as LocaleCode, metadata);
-    await service.translate("de" as LocaleCode, metadata);
+    await service.translate("de", metadata);
+    await service.translate("de", metadata);
 
     expect(Object.keys(translate.mock.calls[1][1])).toEqual(["b"]);
   });

--- a/packages/new-compiler/src/translators/translation-service.test.ts
+++ b/packages/new-compiler/src/translators/translation-service.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LocaleCode } from "lingo.dev/spec";
+
+import { PartialTranslationError, type TranslatableEntry } from "./api";
+import { TranslationService } from "./translation-service";
+import { MemoryTranslationCache } from "./memory-cache";
+import type { MetadataSchema } from "../types";
+import type { Logger } from "../utils/logger";
+
+const silentLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as Logger;
+
+type TranslateFn = (locale: LocaleCode, entries: Record<string, TranslatableEntry>) => Promise<Record<string, string>>;
+
+function metadataOf(entries: Record<string, string>): MetadataSchema {
+  return Object.fromEntries(
+    Object.entries(entries).map(([hash, sourceText]) => [hash, { sourceText, context: {} }]),
+  ) as MetadataSchema;
+}
+
+// The service builds its own translator and cache, so there is no constructor
+// seam. Take the pseudotranslator path, which needs no API keys, then swap both
+// collaborators for controllable ones.
+function makeService(translate: TranslateFn) {
+  const service = new TranslationService(
+    {
+      sourceLocale: "en" as LocaleCode,
+      pluralization: { enabled: false },
+      models: "lingo.dev",
+      environment: "development",
+      dev: { usePseudotranslator: true },
+      cacheDir: "/tmp/lingo-test-cache-unused",
+    } as never,
+    silentLogger,
+  );
+
+  const cache = new MemoryTranslationCache();
+  Object.assign(service as never, {
+    translator: { config: {}, translate },
+    cache,
+  });
+
+  return { service, cache };
+}
+
+describe("TranslationService.translate on a failed run", () => {
+  it("caches the entries the translator finished before it failed, because they were already billed", async () => {
+    const { service, cache } = makeService(async () => {
+      throw new PartialTranslationError(
+        { a: "Alpha-de", b: "Bravo-de" },
+        new Error("Lingo.dev API translation to de timed out after 60000ms"),
+      );
+    });
+
+    const result = await service.translate("de" as LocaleCode, metadataOf({ a: "Alpha", b: "Bravo", c: "Charlie" }));
+
+    expect(await cache.get("de" as LocaleCode)).toEqual({
+      a: "Alpha-de",
+      b: "Bravo-de",
+    });
+    expect(result.translations).toMatchObject({
+      a: "Alpha-de",
+      b: "Bravo-de",
+    });
+  });
+
+  it("still reports the failure so the build does not go green", async () => {
+    const { service } = makeService(async () => {
+      throw new PartialTranslationError({ a: "Alpha-de" }, new Error("boom"));
+    });
+
+    const result = await service.translate("de" as LocaleCode, metadataOf({ a: "Alpha", b: "Bravo" }));
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({ hash: "all" });
+    expect(result.stats.failed).toBe(1);
+  });
+
+  it("caches nothing when the run fails before any entry completes", async () => {
+    const { service, cache } = makeService(async () => {
+      throw new PartialTranslationError({}, new Error("boom"));
+    });
+
+    await service.translate("de" as LocaleCode, metadataOf({ a: "Alpha" }));
+
+    expect(await cache.get("de" as LocaleCode)).toEqual({});
+  });
+
+  it("survives a plain error that carries no partial results", async () => {
+    const { service, cache } = makeService(async () => {
+      throw new Error("network down");
+    });
+
+    const result = await service.translate("de" as LocaleCode, metadataOf({ a: "Alpha" }));
+
+    expect(await cache.get("de" as LocaleCode)).toEqual({});
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it("does not re-request what the failed run already cached", async () => {
+    const translate = vi
+      .fn<TranslateFn>()
+      .mockRejectedValueOnce(new PartialTranslationError({ a: "Alpha-de" }, new Error("timeout")))
+      .mockResolvedValueOnce({ b: "Bravo-de" });
+    const { service } = makeService(translate);
+    const metadata = metadataOf({ a: "Alpha", b: "Bravo" });
+
+    await service.translate("de" as LocaleCode, metadata);
+    await service.translate("de" as LocaleCode, metadata);
+
+    expect(Object.keys(translate.mock.calls[1][1])).toEqual(["b"]);
+  });
+});

--- a/packages/new-compiler/src/translators/translation-service.test.ts
+++ b/packages/new-compiler/src/translators/translation-service.test.ts
@@ -24,10 +24,6 @@ function metadataOf(entries: Record<string, string>): MetadataSchema {
   ) as MetadataSchema;
 }
 
-// TranslationService builds its own translator and cache, so there is no
-// constructor seam. Take the pseudotranslator branch, which needs no API keys,
-// then swap both collaborators. The cast names the members so a rename fails to
-// compile rather than silently leaving the real translator wired in.
 function makeService(translate: TranslateFn) {
   const service = new TranslationService(
     {
@@ -77,7 +73,7 @@ describe("TranslationService.translate on a failed run", () => {
     });
   });
 
-  it("should still report the failure so the build does not go green", async () => {
+  it("should count only the hashes still missing a translation", async () => {
     const { service } = makeService(async () => {
       throw new PartialTranslationError("boom", { a: "Alpha-de" }, undefined);
     });

--- a/packages/new-compiler/src/translators/translation-service.ts
+++ b/packages/new-compiler/src/translators/translation-service.ts
@@ -9,7 +9,11 @@
  */
 
 import type { TranslationCache } from "./cache";
-import type { TranslatableEntry, Translator } from "./api";
+import {
+  PartialTranslationError,
+  type TranslatableEntry,
+  type Translator,
+} from "./api";
 import type { LingoEnvironment, MetadataSchema } from "../types";
 import {
   type PluralizationConfig,
@@ -237,6 +241,7 @@ Set the required API keys for real translations.`);
     // Step 8: Translate or return source text
     let newTranslations: Record<string, string> = { ...overriddenTranslations };
     const errors: TranslationError[] = [];
+    let translationFailed = false;
 
     if (locale === this.config.sourceLocale) {
       // For source locale, just return the (possibly pluralized) sourceText
@@ -268,36 +273,35 @@ Set the required API keys for real translations.`);
           this.logger.debug(`Stack trace: ${error.stack}`);
         }
 
-        return {
-          translations: this.pickTranslations(
-            cachedTranslations,
-            workingHashes,
-          ),
-          errors: [
-            {
-              hash: "all",
-              sourceText: "all",
-              error: errorMessage,
-            },
-          ],
-          stats: {
-            total: workingHashes.length,
-            cached: cachedCount,
-            translated: 0,
-            failed: uncachedHashes.length,
-          },
+        // Keep whatever came back before the failure. Those entries were
+        // already generated and billed, so dropping them makes the next build
+        // pay for the same source text again. The error is still reported, so
+        // the build fails exactly as loudly as before.
+        translationFailed = true;
+        newTranslations = {
+          ...overriddenTranslations,
+          ...(error instanceof PartialTranslationError
+            ? error.partialTranslations
+            : {}),
         };
+        errors.push({
+          hash: "all",
+          sourceText: "all",
+          error: errorMessage,
+        });
       }
 
       // Check for partial failures (some hashes didn't get translated)
-      for (const hash of uncachedHashes) {
-        if (!newTranslations[hash]) {
-          const entry = filteredMetadata[hash];
-          errors.push({
-            hash,
-            sourceText: entry?.sourceText || "",
-            error: "Translator doesn't return translation",
-          });
+      if (!translationFailed) {
+        for (const hash of uncachedHashes) {
+          if (!newTranslations[hash]) {
+            const entry = filteredMetadata[hash];
+            errors.push({
+              hash,
+              sourceText: entry?.sourceText || "",
+              error: "Translator doesn't return translation",
+            });
+          }
         }
       }
     }
@@ -328,7 +332,7 @@ Set the required API keys for real translations.`);
         total: workingHashes.length,
         cached: cachedCount,
         translated: Object.keys(newTranslations).length,
-        failed: errors.length,
+        failed: uncachedHashes.filter((hash) => !newTranslations[hash]).length,
       },
     };
   }

--- a/packages/new-compiler/src/translators/translation-service.ts
+++ b/packages/new-compiler/src/translators/translation-service.ts
@@ -241,7 +241,6 @@ Set the required API keys for real translations.`);
     // Step 8: Translate or return source text
     let newTranslations: Record<string, string> = { ...overriddenTranslations };
     const errors: TranslationError[] = [];
-    let translationFailed = false;
 
     if (locale === this.config.sourceLocale) {
       // For source locale, just return the (possibly pluralized) sourceText
@@ -263,36 +262,8 @@ Set the required API keys for real translations.`);
         );
         // Merge translated texts with overridden translations
         newTranslations = { ...overriddenTranslations, ...translatedTexts };
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        this.logger.error(
-          `Translation failed for locale "${locale}": ${errorMessage}`,
-        );
-        if (error instanceof Error && error.stack) {
-          this.logger.debug(`Stack trace: ${error.stack}`);
-        }
 
-        // Keep whatever came back before the failure. Those entries were
-        // already generated and billed, so dropping them makes the next build
-        // pay for the same source text again. The error is still reported, so
-        // the build fails exactly as loudly as before.
-        translationFailed = true;
-        newTranslations = {
-          ...overriddenTranslations,
-          ...(error instanceof PartialTranslationError
-            ? error.partialTranslations
-            : {}),
-        };
-        errors.push({
-          hash: "all",
-          sourceText: "all",
-          error: errorMessage,
-        });
-      }
-
-      // Check for partial failures (some hashes didn't get translated)
-      if (!translationFailed) {
+        // Check for partial failures (some hashes didn't get translated)
         for (const hash of uncachedHashes) {
           if (!newTranslations[hash]) {
             const entry = filteredMetadata[hash];
@@ -303,6 +274,24 @@ Set the required API keys for real translations.`);
             });
           }
         }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        this.logger.error(
+          `Translation failed for locale "${locale}": ${errorMessage}`,
+        );
+        if (error instanceof Error && error.stack) {
+          this.logger.debug(`Stack trace: ${error.stack}`);
+        }
+
+        if (error instanceof PartialTranslationError) {
+          Object.assign(newTranslations, error.partialTranslations);
+        }
+        errors.push({
+          hash: "all",
+          sourceText: "all",
+          error: errorMessage,
+        });
       }
     }
 

--- a/packages/new-compiler/src/translators/translation-service.ts
+++ b/packages/new-compiler/src/translators/translation-service.ts
@@ -321,7 +321,9 @@ Set the required API keys for real translations.`);
         total: workingHashes.length,
         cached: cachedCount,
         translated: Object.keys(newTranslations).length,
-        failed: uncachedHashes.filter((hash) => !newTranslations[hash]).length,
+        failed: uncachedHashes.filter(
+          (hash) => filteredMetadata[hash] && !newTranslations[hash],
+        ).length,
       },
     };
   }


### PR DESCRIPTION
## Problem

When a translation run fails partway through, the compiler discards every entry that already came back successfully.

`TranslationService.translate` writes to the cache in exactly one place (`translation-service.ts`, step 5). The `catch` around `translator.translate()` sits above it and returns early, so that write is unreachable whenever translation throws. `LingoTranslator.translateDictionary` compounds it: chunks are translated in a sequential loop with no inner `try`, so a failure on chunk 7 discards chunks 1-6 along with it.

Those discarded entries were already generated and billed. Because the next build computes its work list as `uncachedHashes = workingHashes.filter(hash => !cachedTranslations[hash])`, nothing was persisted, so the identical set of strings is submitted and paid for again on every subsequent build.

This is most visible behind the 60s `DEFAULT_TIMEOUTS.AI_API` ceiling (#2053), but it is not specific to timeouts: any throw on the translation path loses the completed work.

## Change

- `PartialTranslationError` in `translators/api.ts` carries the entries that completed, plus the original error as `cause`. The `Translator` interface is unchanged.
- `LingoTranslator.translateDictionary` wraps the chunk loop and throws `PartialTranslationError` with the chunks that finished.
- `TranslationService.translate` no longer returns early from the `catch`. It merges the partial results into `newTranslations`, still pushes the `hash: "all"` error, and falls through to the cache write.
- `stats.failed` now counts hashes that genuinely lack a translation rather than `errors.length`. Same number on the success path; it stopped lying on the failure path.

The failure contract is unchanged: the error is still reported, so `build-translator` still fails the build on a non-empty `errors` array. The only difference is that the cache keeps what was already paid for.

## Tests

`withTimeout` and this path had no tests. Added seven, covering both halves.

Verified they fail without the change. With the behaviour files reverted to `main` (keeping `PartialTranslationError` so it still compiles):

```
× hands back the chunks that completed before the failure
× keeps the original error reachable as the cause
× caches the entries the translator finished before it failed
× still reports the failure so the build does not go green
× does not re-request what the failed run already cached

Tests  5 failed | 2 passed (7)
```

The two that pass in both states are the guard cases: a run that fails before any entry completes, and a plain error carrying no partials. Neither should write to the cache.

With the change, the full package suite is green: `15 files, 226 passed, 1 todo`.

The load-bearing assertion is the last one. Two consecutive runs where the first fails after partial completion: the second requests only the missing hash, instead of both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translation failures now preserve successfully completed translations.
  * Completed translations are cached and reused during retries, avoiding repeated work.
  * Error details remain available while partial results are returned, including timeout failures.

* **Bug Fixes**
  * Improved translation statistics when failures occur.
  * Prevented misleading missing-translation validation after a translator error.
  * Builds continue to report failures while retaining completed translation work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->