### PR TITLE
fix(cli): stop rewriting i18n.lock once per task

### DIFF
--- a/.changeset/lockfile-write-amplification.md
+++ b/.changeset/lockfile-write-amplification.md
@@ -1,0 +1,20 @@
+---
+"lingo.dev": patch
+---
+
+Speed up `lingo.dev run` on projects with many bucket paths and locales.
+
+Every translation task rewrote the whole `i18n.lock`, so a run performed
+`patterns × locales` full read-modify-write cycles to persist `patterns`
+sections. Since every target locale of a bucket path derives its checksums from
+the same source data, all but the first write per pattern stored identical
+bytes. A run now writes a pattern's section once, and those writes are
+serialized against each other.
+
+Loading the lockfile also ran the deduplication pass — a full CST parse plus a
+re-serialization of the entire file — on every load. Deduplication only repairs
+a hand-merged lockfile, which is exactly the case `YAML.parse` rejects, so the
+load now tries the plain parse first and falls back to the repair path only when
+that fails. Malformed and hand-merged lockfiles keep loading exactly as before.
+
+The contents of `i18n.lock` are unchanged.

--- a/packages/cli/src/cli/cmd/run/execute-checksums.spec.ts
+++ b/packages/cli/src/cli/cmd/run/execute-checksums.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import pLimit from "p-limit";
+
+import { persistChecksums } from "./execute";
+import { CmdRunContext } from "./_types";
+
+function setup(flags: Partial<CmdRunContext["flags"]> = {}) {
+  const writes: Record<string, string>[] = [];
+  const deltaProcessor = {
+    saveChecksums: vi.fn(async (checksums: Record<string, string>) => {
+      writes.push({ ...checksums });
+    }),
+  } as any;
+
+  return {
+    writes,
+    deltaProcessor,
+    args: {
+      ctx: { flags } as CmdRunContext,
+      ioLimiter: pLimit(1),
+      lastWrittenChecksums: new Map<string, string>(),
+      deltaProcessor,
+    },
+  };
+}
+
+describe("persistChecksums", () => {
+  const PATTERN = "src/i18n/locales/[locale]/auth.ts";
+
+  it("writes once when every locale of a pattern produces the same payload", async () => {
+    const { args, writes } = setup();
+    const checksums = { "auth.title": "abc123" };
+
+    for (let locale = 0; locale < 24; locale++) {
+      await persistChecksums({ ...args, bucketPathPattern: PATTERN, checksums });
+    }
+
+    expect(writes).toEqual([{ "auth.title": "abc123" }]);
+  });
+
+  // Two bucket entries can share one path pattern - they are deduped by
+  // `pathPattern::delimiter`, while the lockfile section is keyed by the
+  // pattern alone - so one section can legitimately receive alternating
+  // payloads. Skipping a repeat payload must never leave the wrong one on disk.
+  it("rewrites when the payload for a pattern alternates (A, B, A)", async () => {
+    const { args, writes } = setup();
+    const a = { key: "payload-a" };
+    const b = { key: "payload-b" };
+
+    for (const checksums of [a, b, a]) {
+      await persistChecksums({ ...args, bucketPathPattern: PATTERN, checksums });
+    }
+
+    expect(writes).toEqual([a, b, a]);
+    expect(writes.at(-1)).toEqual(a);
+  });
+
+  it("tracks patterns independently", async () => {
+    const { args, writes } = setup();
+    const other = "src/i18n/locales/[locale]/lab.ts";
+
+    await persistChecksums({ ...args, bucketPathPattern: PATTERN, checksums: { a: "1" } });
+    await persistChecksums({ ...args, bucketPathPattern: other, checksums: { b: "2" } });
+    await persistChecksums({ ...args, bucketPathPattern: PATTERN, checksums: { a: "1" } });
+    await persistChecksums({ ...args, bucketPathPattern: other, checksums: { b: "2" } });
+
+    expect(writes).toEqual([{ a: "1" }, { b: "2" }]);
+  });
+
+  it("writes nothing when --target-locale narrows the run", async () => {
+    const { args, writes } = setup({ targetLocale: ["de-DE"] });
+
+    await persistChecksums({ ...args, bucketPathPattern: PATTERN, checksums: { a: "1" } });
+
+    expect(writes).toEqual([]);
+  });
+
+  it("does not mark a pattern as written when the write fails", async () => {
+    const { args, writes, deltaProcessor } = setup();
+    deltaProcessor.saveChecksums.mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(
+      persistChecksums({ ...args, bucketPathPattern: PATTERN, checksums: { a: "1" } }),
+    ).rejects.toThrow("disk full");
+
+    // A later locale of the same pattern must retry rather than assume success.
+    await persistChecksums({ ...args, bucketPathPattern: PATTERN, checksums: { a: "1" } });
+    expect(writes).toEqual([{ a: "1" }]);
+  });
+
+  it("serializes concurrent writes through the shared io limiter", async () => {
+    const { args } = setup();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    args.deltaProcessor.saveChecksums = vi.fn(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+    });
+
+    await Promise.all(
+      Array.from({ length: 8 }, (_, i) =>
+        persistChecksums({
+          ...args,
+          bucketPathPattern: `pattern-${i}`,
+          checksums: { key: `value-${i}` },
+        }),
+      ),
+    );
+
+    expect(maxInFlight).toBe(1);
+  });
+});

--- a/packages/cli/src/cli/cmd/run/execute-checksums.spec.ts
+++ b/packages/cli/src/cli/cmd/run/execute-checksums.spec.ts
@@ -88,6 +88,25 @@ describe("persistChecksums", () => {
     expect(writes).toEqual([{ a: "1" }]);
   });
 
+  it("writes once when a pattern is persisted concurrently", async () => {
+    const { args, writes, deltaProcessor } = setup();
+    deltaProcessor.saveChecksums.mockImplementation(
+      async (checksums: Record<string, string>) => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        writes.push({ ...checksums });
+      },
+    );
+    const checksums = { "auth.title": "abc123" };
+
+    await Promise.all(
+      Array.from({ length: 8 }, () =>
+        persistChecksums({ ...args, bucketPathPattern: PATTERN, checksums }),
+      ),
+    );
+
+    expect(writes).toEqual([{ "auth.title": "abc123" }]);
+  });
+
   it("serializes concurrent writes through the shared io limiter", async () => {
     const { args } = setup();
     let inFlight = 0;

--- a/packages/cli/src/cli/cmd/run/execute.ts
+++ b/packages/cli/src/cli/cmd/run/execute.ts
@@ -8,6 +8,7 @@ import { CmdRunContext, CmdRunTask, CmdRunTaskResult } from "./_types";
 import { commonTaskRendererOptions } from "./_const";
 import { createDeltaProcessor, Delta } from "../../utils/delta";
 import { computeProcessableData, createLoaderForTask } from "./_utils";
+import { md5 } from "../../utils/md5";
 
 const WARN_CONCURRENCY_COUNT = 30;
 
@@ -58,7 +59,17 @@ export default async function execute(input: CmdRunContext) {
           }
 
           const i18nLimiter = pLimit(effectiveConcurrency);
+          // Serializes every i18n.lock write. Each write is a read-modify-write
+          // of the whole file, and the per-pattern limiters below cannot guard
+          // it because all patterns share one lockfile.
           const ioLimiter = pLimit(1);
+
+          // Checksum payload last written to i18n.lock per bucket path pattern,
+          // scoped to this run. Every target locale of a pattern derives its
+          // checksums from the same source data, so without this each locale
+          // rewrites the entire lockfile with byte-identical content -
+          // patterns x locales full-file rewrites to persist patterns sections.
+          const lastWrittenChecksums = new Map<string, string>();
 
           const perFileIoLimiters = new Map<string, LimitFunction>();
           const getFileIoLimiter = (
@@ -86,6 +97,7 @@ export default async function execute(input: CmdRunContext) {
                 ioLimiter,
                 i18nLimiter,
                 initialChecksumsMap,
+                lastWrittenChecksums,
                 getFileIoLimiter,
                 onDone() {
                   task.title = createExecutionProgressMessage(ctx);
@@ -146,6 +158,39 @@ function createExecutionProgressMessage(ctx: CmdRunContext) {
   }, Failed ${chalk.red(failedTasksCount)}, Skipped ${chalk.dim(skippedTasksCount)}`;
 }
 
+/**
+ * Persists a pattern's source checksums to i18n.lock, skipping the write when
+ * this run already wrote exactly this payload for this pattern.
+ *
+ * The lockfile section is keyed by the bucket path pattern and holds checksums
+ * of the source data, which is identical for every target locale of that
+ * pattern - so all but the first locale rewrite the whole file with the same
+ * bytes. Keying on the last payload written (rather than on every payload ever
+ * written) keeps the on-disk result identical to writing unconditionally, even
+ * when two bucket entries share one path pattern and produce different source
+ * data, e.g. entries that differ only by locale delimiter.
+ */
+export async function persistChecksums(args: {
+  ctx: CmdRunContext;
+  ioLimiter: LimitFunction;
+  lastWrittenChecksums: Map<string, string>;
+  bucketPathPattern: string;
+  deltaProcessor: ReturnType<typeof createDeltaProcessor>;
+  checksums: Record<string, string>;
+}) {
+  if (args.ctx.flags.targetLocale?.length) {
+    return;
+  }
+
+  const payloadHash = md5(args.checksums);
+  if (args.lastWrittenChecksums.get(args.bucketPathPattern) === payloadHash) {
+    return;
+  }
+
+  await args.ioLimiter(() => args.deltaProcessor.saveChecksums(args.checksums));
+  args.lastWrittenChecksums.set(args.bucketPathPattern, payloadHash);
+}
+
 function createWorkerTask(args: {
   ctx: CmdRunContext;
   assignedTasks: CmdRunTask[];
@@ -153,6 +198,7 @@ function createWorkerTask(args: {
   i18nLimiter: LimitFunction;
   onDone: () => void;
   initialChecksumsMap: Map<string, Record<string, string>>;
+  lastWrittenChecksums: Map<string, string>;
   getFileIoLimiter: (bucketPathPattern: string) => LimitFunction;
 }): ListrTask {
   return {
@@ -213,9 +259,14 @@ function createWorkerTask(args: {
                 // then reports the source as changed.
                 const checksums =
                   await deltaProcessor.createChecksums(sourceData);
-                if (!args.ctx.flags.targetLocale?.length) {
-                  await deltaProcessor.saveChecksums(checksums);
-                }
+                await persistChecksums({
+                  ctx: args.ctx,
+                  ioLimiter: args.ioLimiter,
+                  lastWrittenChecksums: args.lastWrittenChecksums,
+                  bucketPathPattern: assignedTask.bucketPathPattern,
+                  deltaProcessor,
+                  checksums,
+                });
               });
               return {
                 status: "skipped",
@@ -294,9 +345,14 @@ function createWorkerTask(args: {
 
               const checksums =
                 await deltaProcessor.createChecksums(sourceData);
-              if (!args.ctx.flags.targetLocale?.length) {
-                await deltaProcessor.saveChecksums(checksums);
-              }
+              await persistChecksums({
+                ctx: args.ctx,
+                ioLimiter: args.ioLimiter,
+                lastWrittenChecksums: args.lastWrittenChecksums,
+                bucketPathPattern: assignedTask.bucketPathPattern,
+                deltaProcessor,
+                checksums,
+              });
             });
 
             return {

--- a/packages/cli/src/cli/cmd/run/execute.ts
+++ b/packages/cli/src/cli/cmd/run/execute.ts
@@ -187,8 +187,17 @@ export async function persistChecksums(args: {
     return;
   }
 
-  await args.ioLimiter(() => args.deltaProcessor.saveChecksums(args.checksums));
-  args.lastWrittenChecksums.set(args.bucketPathPattern, payloadHash);
+  await args.ioLimiter(async () => {
+    // Re-check under the limiter: callers that reach this concurrently for one
+    // pattern would otherwise all pass the check above before the first write
+    // records the payload, turning one write into several identical ones.
+    if (args.lastWrittenChecksums.get(args.bucketPathPattern) === payloadHash) {
+      return;
+    }
+
+    await args.deltaProcessor.saveChecksums(args.checksums);
+    args.lastWrittenChecksums.set(args.bucketPathPattern, payloadHash);
+  });
 }
 
 function createWorkerTask(args: {

--- a/packages/cli/src/cli/utils/delta-lockfile-load.spec.ts
+++ b/packages/cli/src/cli/utils/delta-lockfile-load.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import YAML from "yaml";
+
+import { createDeltaProcessor } from "./delta";
+
+/**
+ * `loadLock` takes a fast path through `YAML.parse` and only falls back to
+ * `deduplicateLockfileYaml` when that fails. Deduplication is not just a
+ * duplicate-key remover: `YAML.parseDocument` collects syntax errors instead of
+ * throwing, so it also rescues shapes `YAML.parse` rejects outright. These
+ * tests pin every such shape, because skipping the fallback would turn a
+ * lockfile that loads today into a hard failure.
+ */
+describe("loadLock repair path", () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lingo-loadlock-"));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeLock(content: string) {
+    fs.writeFileSync(path.join(tmpDir, "i18n.lock"), content);
+  }
+
+  function readLock() {
+    return fs.readFileSync(path.join(tmpDir, "i18n.lock"), "utf-8");
+  }
+
+  it("loads a well-formed lockfile without rewriting it", async () => {
+    const content = YAML.stringify({
+      version: 1,
+      checksums: { sectionA: { greeting: "abc123" } },
+    });
+    writeLock(content);
+
+    const lock = await createDeltaProcessor("src/[locale].json").loadLock();
+
+    expect(lock.checksums).toEqual({ sectionA: { greeting: "abc123" } });
+    expect(readLock()).toBe(content);
+  });
+
+  it("returns the default lock when the file is absent", async () => {
+    const lock = await createDeltaProcessor("src/[locale].json").loadLock();
+    expect(lock).toEqual({ version: 1, checksums: {} });
+  });
+
+  it("repairs duplicate keys inside a section, keeping the last occurrence", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    writeLock("version: 1\nchecksums:\n  sectionA:\n    greeting: first\n    greeting: second\n");
+
+    const lock = await createDeltaProcessor("src/[locale].json").loadLock();
+
+    expect(lock.checksums).toEqual({ sectionA: { greeting: "second" } });
+    // The repaired content is written back so later loads take the fast path.
+    expect(readLock()).not.toContain("greeting: first");
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Removed 1 duplicate entry from i18n.lock"),
+    );
+    logSpy.mockRestore();
+  });
+
+  // These shapes all make `YAML.parse` throw while `YAML.parseDocument`
+  // recovers. They load today and must keep loading.
+  it.each([
+    [
+      "a duplicate section id",
+      "version: 1\nchecksums:\n  sectionA:\n    a: aaa\n  sectionA:\n    b: bbb\n",
+    ],
+    [
+      "a duplicate top-level checksums key",
+      "version: 1\nchecksums:\n  sectionA:\n    a: aaa\nchecksums:\n  sectionB:\n    b: bbb\n",
+    ],
+    [
+      "a duplicate top-level version key",
+      "version: 1\nversion: 1\nchecksums:\n  sectionA:\n    a: aaa\n",
+    ],
+  ])("still loads a lockfile with %s", async (_label, content) => {
+    writeLock(content);
+    expect(() => YAML.parse(content)).toThrow();
+
+    const lock = await createDeltaProcessor("src/[locale].json").loadLock();
+
+    expect(lock.version).toBe(1);
+    expect(Object.keys(lock.checksums).length).toBeGreaterThan(0);
+  });
+
+  it("keeps the fast path byte-identical to the repair path on clean input", async () => {
+    const content = YAML.stringify({
+      version: 1,
+      checksums: {
+        // numeric-like keys are real: demo/php and demo/txt use them
+        sectionA: { "0": "aaa", "1": "bbb", "10": "ccc", named: "ddd" },
+        sectionB: { "unicode.ключ": "eee", "emoji🎉": "fff" },
+      },
+    });
+    writeLock(content);
+
+    const processor = createDeltaProcessor("src/[locale].json");
+    const lock = await processor.loadLock();
+    await processor.saveLock(lock);
+
+    expect(readLock()).toBe(content);
+  });
+});

--- a/packages/cli/src/cli/utils/delta.ts
+++ b/packages/cli/src/cli/utils/delta.ts
@@ -100,6 +100,17 @@ export function createDeltaProcessor(fileKey: string) {
         } as const;
       }
 
+      // Fast path: a lockfile the CLI itself wrote always parses directly.
+      // Deduplication costs a full CST parse plus a re-serialization of the
+      // whole file, and it only ever repairs a hand-merged lockfile - exactly
+      // the case `YAML.parse` refuses to parse. So try the cheap parse first
+      // and fall back to the repair path on any failure.
+      try {
+        return LockSchema.parse(YAML.parse(lockfileContent));
+      } catch {
+        // Malformed or hand-merged lockfile - repair it below.
+      }
+
       // Deduplicate using the universal function
       const { deduplicatedContent, duplicatesRemoved } = deduplicateLockfileYaml(lockfileContent);
 


### PR DESCRIPTION
Closes ENG-1392.

A customer reported `lingo.dev run --concurrency 50` taking 8m34s for a run whose
only effective change was removing one key from `i18n.lock`.

## Cause

`saveChecksums` is a read-modify-write of the entire lockfile, and it ran once per
translation task:

```
loadLock -> deduplicateLockfileYaml (CST parse + full re-serialize) -> YAML.parse
         -> zod -> mutate one section -> YAML.stringify -> write whole file
```

A run has `patterns × locales` tasks but only `patterns` lockfile sections, and every
target locale of a pattern derives its checksums from the same source data — so all
but the first write per pattern stored byte-identical content. On a 0.5 MB lockfile
one such call measures ~690 ms, which is where the eight minutes went.

The lockfile also got deduplicated on *every* load, not just when it needed repair.

Neither the backend nor Biome is involved: a no-op run makes exactly one API call
(`checkAuth`), and Biome measures 4.5–6.8 ms per call against ~690 ms for the lockfile.

Both halves are recent and individually correct — #1873 added dedupe to every load,
#2091 added the skip-branch write so `--frozen` has a baseline. The cost is their
product.

## Changes

**Write a pattern's section once per run.** `persistChecksums` skips a write when this
run already wrote exactly this payload for this pattern, and routes writes through the
run-wide `pLimit(1)` that already existed at `execute.ts:61` and was never invoked.

The skip is keyed on the **last** payload written per section, not on the set of
payloads ever written. Two bucket entries can share one path pattern — they are
deduped by `pathPattern::delimiter` while the lockfile section is `md5(pathPattern)` —
so one section can legitimately receive A, B, A. A set-based key would skip the final
A and leave B on disk.

**Parse first, repair only on failure.** `loadLock` now tries `YAML.parse` and falls
back to `deduplicateLockfileYaml` only when that throws. Dedupe is not just a
duplicate-key remover: `YAML.parseDocument` collects syntax errors instead of throwing,
so it also rescues duplicate section ids, duplicate top-level keys, unclosed quotes and
multi-document files. All of those still load, because the fallback fires exactly when
the plain parse cannot cope.

`i18n.lock` contents are unchanged.

## Measured

Fixture mirrors the reporter's layout — `src/i18n/locales/[locale]/*.ts`, typescript
bucket, biome formatter, targets already fully translated so every task hits the skip
branch.

| fixture | lockfile | before | after | |
|---|---|---|---|---|
| 30 patterns × 24 locales (720 tasks) | 240 KB | 272 s (CPU 250 s) | 100 s (CPU 46 s) | **2.7×** wall, 5.4× CPU |
| 30 patterns × 8 locales (240 tasks) | 803 KB | 399 s | 24 s | **16.6×** |

The gain scales with lockfile size, since that is what the removed work was
proportional to. After this change the lockfile is no longer the bottleneck — the
residual per-task cost is the pull/push path.

## Verified

End-to-end on the fixture:

- a no-op run leaves `i18n.lock` byte-identical
- `run --frozen` passes with an existing lockfile
- `run --frozen` with no lockfile still bootstraps one, byte-identical to before
- a plain `run` with no lockfile still populates it from the skip branch (the #2091
  contract), byte-identical to `lingo.dev lockfile` output

New tests:

- `execute-checksums.spec.ts` — write-once per pattern, the A/B/A payload sequence,
  per-pattern independence, `--target-locale` suppression, no cache poisoning when a
  write fails, and that writes are serialized. Verified by mutation: swapping the
  implementation to a set-based key fails the A/B/A test and nothing else.
- `delta-lockfile-load.spec.ts` — pins every lockfile shape that only `parseDocument`
  can read, plus the duplicate-key repair, its write-back and its log line.

`packages/cli/src/cli/cmd/lockfile.spec.ts` fails with `Hook timed out in 10000ms`
under the full suite. That is pre-existing — `origin/main` gives `1 failed | 941
passed`, this branch gives `1 failed | 948 passed`, same test.

## Noted, not changed here

- `run --concurrency`'s help text says "maximum 10" while the schema has no cap, so
  `--concurrency 50` is accepted silently. Adding `.max()` would break the reporter's
  current invocation, so the text needs fixing instead.
- `execute.ts`'s `onDone()` is never invoked, so the `Processed X/Y` progress line
  never renders.
- The #1873 changeset claims deduplication "automatically handles Git merge conflicts
  in i18n.lock files". It does not — on real conflict markers it turns the section into
  `null`, and the test named for that case contains no conflict markers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced redundant checksum writes when identical data is processed repeatedly.
  - Serialized checksum persistence for more reliable file operations.

- **Bug Fixes**
  - Preserved valid lockfiles unchanged while repairing duplicate or malformed entries when needed.
  - Maintained retry behavior after failed checksum writes.

- **Tests**
  - Added coverage for checksum deduplication, retries, locale handling, lockfile repair, logging, and byte-identical saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->