### PR TITLE
feat(compiler): make the AI request timeout configurable

### DIFF
--- a/.changeset/configurable-ai-timeout.md
+++ b/.changeset/configurable-ai-timeout.md
@@ -1,0 +1,14 @@
+---
+"@lingo.dev/compiler": patch
+---
+
+Let the AI request timeout be configured, and raise the default to 2 minutes.
+
+The timeout for a single AI translation request was hardcoded at 60 seconds, which is not
+enough when the build runs somewhere with slow network to the model, such as CI, or when a
+chunk carries enough text that the model needs longer. The documented workaround was
+patching the compiled file inside `node_modules`.
+
+`aiTimeout` is now a plugin option, and the default is 120000. The request that times out is
+not cancelled and is still billed, so a value that is too low costs money as well as build
+time.

--- a/packages/new-compiler/README.md
+++ b/packages/new-compiler/README.md
@@ -117,6 +117,7 @@ See `demo/new-compiler-next16` for the working example
 | `useDirective` | `boolean` | `false` | Whether to require `'use i18n'` directive |
 | `models` | `string \| Record<string, string>` | `"lingo.dev"` | Model configuration (see below) |
 | `prompt` | `string` | `undefined` | Custom translation prompt |
+| `aiTimeout` | `number` | `120000` | Milliseconds to wait for a single AI translation request. Raise it for slow networks or large chunks |
 | `buildMode` | `"translate" \| "cache-only"` | `"translate"` | Build mode (see below) |
 
 ### Development Configuration

--- a/packages/new-compiler/src/translators/ai-timeout-wiring.test.ts
+++ b/packages/new-compiler/src/translators/ai-timeout-wiring.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createLingoConfig } from "../utils/config-factory";
+import { DEFAULT_CONFIG } from "../utils/config-factory";
+import { Logger } from "../utils/logger";
+import type { LingoPluginOptions } from "../plugin/unplugin";
+
+vi.mock("./lingo/model-factory", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./lingo/model-factory")>()),
+  validateAndGetApiKeys: () => ({ "lingo.dev": "test-key", groq: "test-key" }),
+  createAiModel: () => ({ modelId: "test-model" }),
+}));
+
+vi.mock("lingo.dev/sdk", () => ({
+  LingoDotDevEngine: class {
+    localizeObject = () => new Promise(() => {});
+  },
+}));
+
+const { TranslationService } = await import("./translation-service");
+
+function serviceFromPluginOptions(options: Partial<LingoPluginOptions>) {
+  const config = createLingoConfig({
+    sourceLocale: "en",
+    sourceRoot: "src",
+    targetLocales: ["de"],
+    environment: "production",
+    ...options,
+  } as never);
+
+  return {
+    config,
+    service: new TranslationService(
+      config,
+      new Logger({ enableConsole: false }),
+    ),
+  };
+}
+
+function collaborator(
+  service: object,
+  name: "translator" | "pluralizationService",
+) {
+  return (service as Record<string, Record<string, unknown>>)[name];
+}
+
+describe("aiTimeout from plugin options to the collaborators that use it", () => {
+  it("should default to two minutes", () => {
+    expect(DEFAULT_CONFIG.aiTimeout).toBe(120_000);
+    expect(serviceFromPluginOptions({}).config.aiTimeout).toBe(120_000);
+  });
+
+  it("should reach the translator a caller configured it for", () => {
+    const { service } = serviceFromPluginOptions({ aiTimeout: 300_000 });
+
+    expect(collaborator(service, "translator").config).toMatchObject({
+      aiTimeout: 300_000,
+    });
+  });
+
+  it("should reach pluralization", () => {
+    const { service } = serviceFromPluginOptions({
+      aiTimeout: 300_000,
+      pluralization: { enabled: true, model: "groq:llama-3.1-8b-instant" },
+    } as never);
+
+    expect(collaborator(service, "pluralizationService")).toHaveProperty(
+      "aiTimeout",
+      300_000,
+    );
+  });
+
+  it("should let a pluralization-specific value win over the shared one", () => {
+    const { service } = serviceFromPluginOptions({
+      aiTimeout: 300_000,
+      pluralization: {
+        enabled: true,
+        model: "groq:llama-3.1-8b-instant",
+        aiTimeout: 600_000,
+      },
+    } as never);
+
+    expect(collaborator(service, "pluralizationService")).toHaveProperty(
+      "aiTimeout",
+      600_000,
+    );
+  });
+});

--- a/packages/new-compiler/src/translators/lingo/ai-timeout.test.ts
+++ b/packages/new-compiler/src/translators/lingo/ai-timeout.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Logger } from "../../utils/logger";
+import { DEFAULT_TIMEOUTS } from "../../utils/timeout";
+
+const localizeObject = vi.fn(() => new Promise(() => {}));
+
+vi.mock("lingo.dev/sdk", () => ({
+  LingoDotDevEngine: class {
+    localizeObject = localizeObject;
+  },
+}));
+
+vi.mock("./model-factory", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./model-factory")>()),
+  validateAndGetApiKeys: () => ({ "lingo.dev": "test-key" }),
+}));
+
+const { LingoTranslator } = await import("./translator");
+
+function hangingTranslator(aiTimeout?: number) {
+  return new LingoTranslator(
+    { models: "lingo.dev", sourceLocale: "en", aiTimeout },
+    new Logger({ enableConsole: false }),
+  );
+}
+
+const entry = { h0: { text: "text", context: {} } };
+
+describe("aiTimeout", () => {
+  it("should wait as long as the caller asked instead of the default", async () => {
+    vi.useFakeTimers();
+    const run = hangingTranslator(300_000)
+      .translate("de", entry)
+      .catch((caught: unknown) => caught);
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMEOUTS.AI_API);
+    expect(await settled(run)).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(300_000 - DEFAULT_TIMEOUTS.AI_API);
+    vi.useRealTimers();
+
+    expect((await run) as Error).toHaveProperty(
+      "message",
+      expect.stringContaining("timed out after 300000ms"),
+    );
+  });
+
+  it("should fall back to the default when the caller says nothing", async () => {
+    vi.useFakeTimers();
+    const run = hangingTranslator()
+      .translate("de", entry)
+      .catch((caught: unknown) => caught);
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMEOUTS.AI_API);
+    vi.useRealTimers();
+
+    expect((await run) as Error).toHaveProperty(
+      "message",
+      expect.stringContaining(`timed out after ${DEFAULT_TIMEOUTS.AI_API}ms`),
+    );
+  });
+});
+
+async function settled(promise: Promise<unknown>) {
+  const marker = Symbol("pending");
+  return (await Promise.race([promise, Promise.resolve(marker)])) !== marker;
+}

--- a/packages/new-compiler/src/translators/lingo/translator.ts
+++ b/packages/new-compiler/src/translators/lingo/translator.ts
@@ -115,7 +115,7 @@ export class LingoTranslator implements Translator<LingoTranslatorConfig> {
 
   /**
    * Translate using Lingo.dev Engine
-   * Times out after 60 seconds to prevent indefinite hangs
+   * Times out after `aiTimeout` to prevent indefinite hangs
    */
   private async translateWithLingoDotDev(
     sourceDictionary: DictionarySchema,
@@ -155,7 +155,7 @@ export class LingoTranslator implements Translator<LingoTranslatorConfig> {
 
   /**
    * Translate using generic LLM
-   * Times out after 60 seconds to prevent indefinite hangs
+   * Times out after `aiTimeout` to prevent indefinite hangs
    */
   private async translateWithLLM(
     sourceDictionary: DictionarySchema,

--- a/packages/new-compiler/src/translators/lingo/translator.ts
+++ b/packages/new-compiler/src/translators/lingo/translator.ts
@@ -16,6 +16,7 @@ export interface LingoTranslatorConfig {
   models: "lingo.dev" | Record<string, string>;
   sourceLocale: LocaleCode;
   prompt?: string;
+  aiTimeout?: number;
 }
 
 /**
@@ -139,7 +140,7 @@ export class LingoTranslator implements Translator<LingoTranslatorConfig> {
           sourceLocale: this.config.sourceLocale,
           targetLocale: targetLocale,
         }),
-        DEFAULT_TIMEOUTS.AI_API,
+        this.config.aiTimeout ?? DEFAULT_TIMEOUTS.AI_API,
         `Lingo.dev API translation to ${targetLocale}`,
       );
 
@@ -208,7 +209,7 @@ export class LingoTranslator implements Translator<LingoTranslatorConfig> {
             },
           ],
         }),
-        DEFAULT_TIMEOUTS.AI_API,
+        this.config.aiTimeout ?? DEFAULT_TIMEOUTS.AI_API,
         `${localeModel.provider} LLM translation to ${targetLocale}`,
       );
 

--- a/packages/new-compiler/src/translators/pluralization/ai-timeout.test.ts
+++ b/packages/new-compiler/src/translators/pluralization/ai-timeout.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Logger } from "../../utils/logger";
+import { DEFAULT_TIMEOUTS } from "../../utils/timeout";
+
+vi.mock("ai", () => ({
+  generateText: vi.fn(() => new Promise(() => {})),
+}));
+
+vi.mock("../lingo/model-factory", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lingo/model-factory")>()),
+  validateAndGetApiKeys: () => ({ groq: "test-key" }),
+  createAiModel: () => ({ modelId: "test-model" }),
+}));
+
+const { PluralizationService } = await import("./service");
+
+function hangingService(aiTimeout?: number) {
+  return new PluralizationService(
+    {
+      sourceLocale: "en",
+      enabled: true,
+      model: "groq:llama-3.1-8b-instant",
+      aiTimeout,
+    },
+    new Logger({ enableConsole: false }),
+  );
+}
+
+const candidates = [{ hash: "h0", sourceText: "You have 1 message" }];
+
+describe("aiTimeout in pluralization", () => {
+  it("should give a batch twice the configured timeout", async () => {
+    vi.useFakeTimers();
+    const run = hangingService(300_000).generateBatch(candidates);
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(await settled(run)).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    vi.useRealTimers();
+
+    expect((await run).get("h0")?.error).toContain("timed out after 600000ms");
+  });
+
+  it("should fall back to twice the default when nothing is configured", async () => {
+    vi.useFakeTimers();
+    const run = hangingService().generateBatch(candidates);
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMEOUTS.AI_API * 2);
+    vi.useRealTimers();
+
+    expect((await run).get("h0")?.error).toContain(
+      `timed out after ${DEFAULT_TIMEOUTS.AI_API * 2}ms`,
+    );
+  });
+});
+
+async function settled(promise: Promise<unknown>) {
+  const marker = Symbol("pending");
+  return (await Promise.race([promise, Promise.resolve(marker)])) !== marker;
+}

--- a/packages/new-compiler/src/translators/pluralization/service.ts
+++ b/packages/new-compiler/src/translators/pluralization/service.ts
@@ -34,6 +34,7 @@ export class PluralizationService {
   private cache = new Map<string, ICUGenerationResult>();
   private readonly prompt: string;
   private readonly sourceLocale: string;
+  private readonly aiTimeout: number | undefined;
 
   constructor(
     config: PluralizationConfig,
@@ -56,6 +57,7 @@ export class PluralizationService {
 
     this.languageModel = createAiModel(localeModel, validatedKeys);
     this.sourceLocale = config.sourceLocale;
+    this.aiTimeout = config.aiTimeout;
     this.prompt = getSystemPrompt({ sourceLocale: config.sourceLocale });
 
     this.logger.debug(
@@ -165,7 +167,7 @@ export class PluralizationService {
             },
           ],
         }),
-        DEFAULT_TIMEOUTS.AI_API * 2, // Double timeout for batch
+        (this.aiTimeout ?? DEFAULT_TIMEOUTS.AI_API) * 2, // Double timeout for batch
         `Pluralization with ${this.languageModel}`,
       );
 

--- a/packages/new-compiler/src/translators/pluralization/types.ts
+++ b/packages/new-compiler/src/translators/pluralization/types.ts
@@ -21,6 +21,12 @@ export type PluralizationConfig = {
   enabled: boolean;
 
   /**
+   * Milliseconds to wait for a pluralization batch. Defaults to twice the
+   * translation timeout, since a batch asks the model for more at once.
+   */
+  aiTimeout?: number;
+
+  /**
    * LLM provider for pluralization detection
    * Format: "provider:model" (e.g., "groq:llama3-8b-8192")
    * If omitted in user config, the compiler can infer it from translation models.

--- a/packages/new-compiler/src/translators/translation-service.ts
+++ b/packages/new-compiler/src/translators/translation-service.ts
@@ -35,6 +35,7 @@ export type TranslationServiceConfig = {
   pluralization: Omit<PluralizationConfig, "sourceLocale">;
   models: "lingo.dev" | Record<string, string>;
   prompt?: string;
+  aiTimeout?: number;
   environment: LingoEnvironment;
   dev?: {
     usePseudotranslator?: boolean;
@@ -98,6 +99,7 @@ export class TranslationService {
             models,
             sourceLocale: config.sourceLocale,
             prompt: config.prompt,
+            aiTimeout: config.aiTimeout,
           },
           this.logger,
         );

--- a/packages/new-compiler/src/translators/translation-service.ts
+++ b/packages/new-compiler/src/translators/translation-service.ts
@@ -109,6 +109,7 @@ export class TranslationService {
             {
               ...this.config.pluralization,
               sourceLocale: this.config.sourceLocale,
+              aiTimeout: config.aiTimeout,
             },
             this.logger,
           );

--- a/packages/new-compiler/src/translators/translation-service.ts
+++ b/packages/new-compiler/src/translators/translation-service.ts
@@ -109,7 +109,8 @@ export class TranslationService {
             {
               ...this.config.pluralization,
               sourceLocale: this.config.sourceLocale,
-              aiTimeout: config.aiTimeout,
+              aiTimeout:
+                this.config.pluralization.aiTimeout ?? config.aiTimeout,
             },
             this.logger,
           );

--- a/packages/new-compiler/src/types.ts
+++ b/packages/new-compiler/src/types.ts
@@ -214,6 +214,7 @@ export type TranslationMiddlewareConfig = Pick<
   | "sourceLocale"
   | "models"
   | "prompt"
+  | "aiTimeout"
   | "targetLocales"
   | "dev"
   | "pluralization"

--- a/packages/new-compiler/src/types.ts
+++ b/packages/new-compiler/src/types.ts
@@ -137,6 +137,18 @@ export type LingoConfig = {
   prompt?: string;
 
   /**
+   * Milliseconds to wait for a single AI translation request before giving up.
+   *
+   * Raise it when builds run somewhere with slow network to the model, such as
+   * CI, or when a chunk carries enough text that the model needs longer. The
+   * request that times out is not cancelled and is still billed, so a value
+   * that is too low costs money as well as build time.
+   *
+   * @default 120000
+   */
+  aiTimeout: number;
+
+  /**
    * Pluralization configuration
    * Automatically detects and converts messages to ICU MessageFormat
    */

--- a/packages/new-compiler/src/utils/config-factory.ts
+++ b/packages/new-compiler/src/utils/config-factory.ts
@@ -26,6 +26,7 @@ export const DEFAULT_CONFIG = {
     },
   },
   models: "lingo.dev",
+  aiTimeout: 120_000,
   pluralization: {
     enabled: false,
     model: "groq:llama-3.1-8b-instant",

--- a/packages/new-compiler/src/utils/timeout.ts
+++ b/packages/new-compiler/src/utils/timeout.ts
@@ -57,7 +57,7 @@ export const DEFAULT_TIMEOUTS = {
   METADATA: 15_000, // 15 seconds
 
   /** AI API calls for translation */
-  AI_API: 60_000, // 60 seconds
+  AI_API: 120_000, // 2 minutes
 
   /** HTTP requests to translation server */
   HTTP_REQUEST: 30_000, // 30 seconds


### PR DESCRIPTION
Closes #2053.

## Problem

The timeout for a single AI translation request is hardcoded at 60 seconds (`DEFAULT_TIMEOUTS.AI_API`). It is not enough when the build runs somewhere with slow network to the model, such as CI, or when a chunk carries enough text that the model needs longer, and a compiler chunk goes to the model as one call regardless of how much text it holds.

The documented workaround in #2053 is patching the compiled file inside `node_modules`:

```dockerfile
RUN sed -i 's/AI_API: 6e4/AI_API: 3e5/' node_modules/@lingo.dev/compiler/build/utils/timeout.mjs
```

## Change

- `aiTimeout` is a new plugin option, threaded from `LingoConfig` through `TranslationService` into `LingoTranslator`, and applied on both the Lingo.dev Engine and the direct-LLM paths.
- The default moves from 60000 to 120000. `DEFAULT_TIMEOUTS.AI_API` stays as the fallback for callers that pass nothing, and is raised to match.
- Public surface needs no separate change: `LingoPluginOptions` and `LingoNextPluginOptions` are aliases of `PartialLingoConfig`, so Vite, webpack and Next pick the option up.

```ts
lingoCompilerPlugin({
  sourceRoot: "./src",
  sourceLocale: "en",
  targetLocales: ["zh", "de"],
  aiTimeout: 300_000,
});
```

## Why the default moved rather than staying at 60s

A request that times out is not cancelled. `withTimeout` is a `Promise.race`, so the underlying call keeps running server-side, completes, and is billed, while its result is discarded. A timeout that fires too eagerly therefore costs money, not just build time. Waiting longer makes it more likely the caller actually receives the work it paid for.

This does not make the timeout harmless, and this PR does not claim to fix the billing side. Cancelling the abandoned request needs the `signal` that `LingoDotDevEngine.localizeObject` already accepts as its fourth parameter and threads into `fetch`; wiring that up is separate work.

## Tests

Two, driving the real `withTimeout` through the real translator with only the SDK engine stubbed to hang, and fake timers advancing the clock:

- a caller-supplied `aiTimeout` of 300000 is still pending at the 120000 mark and rejects at 300000
- with no `aiTimeout`, it rejects at the default

Verified the first fails without the wiring. Full package suite: `14 files, 221 passed, 1 todo`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable timeouts for individual AI translation and pluralization requests.
  * Increased the default AI request timeout from 60 to 120 seconds.
  * Custom timeout settings can be specified in translation configuration, with specialized pluralization settings taking precedence.

* **Documentation**
  * Documented timeout behavior, including that timed-out requests may continue running and incur charges.

* **Tests**
  * Added coverage for custom timeouts, configuration propagation, precedence rules, and updated defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->