### PR TITLE
test(compiler): pin the timeout repro to its own deadline

### DIFF
--- a/.changeset/repro-test-independent-of-default.md
+++ b/.changeset/repro-test-independent-of-default.md
@@ -1,0 +1,6 @@
+---
+"@lingo.dev/compiler": patch
+---
+
+Pin the timeout repro test to its own deadline instead of the package default, so raising the
+default does not break it.

--- a/packages/new-compiler/src/translators/lingo/timeout-repro.test.ts
+++ b/packages/new-compiler/src/translators/lingo/timeout-repro.test.ts
@@ -27,19 +27,21 @@ function sourceEntries(count: number) {
   );
 }
 
-describe("the reported failure: a chunk exceeds the 60s API timeout", () => {
+const AI_TIMEOUT = 60_000;
+
+describe("the reported failure: a chunk exceeds the API timeout", () => {
   it("should keep the chunks that finished before the timeout", async () => {
     vi.useFakeTimers();
 
-    // Chunks 1 and 2 come back; chunk 3 hangs, which is what the 60s
-    // DEFAULT_TIMEOUTS.AI_API ceiling turns into a TimeoutError.
+    // Chunks 1 and 2 come back; chunk 3 hangs, which the timeout ceiling
+    // turns into a TimeoutError.
     localizeObject
       .mockImplementationOnce(async (dictionary) => translated(dictionary))
       .mockImplementationOnce(async (dictionary) => translated(dictionary))
       .mockImplementationOnce(() => new Promise(() => {}));
 
     const translator = new LingoTranslator(
-      { models: "lingo.dev", sourceLocale: "en" },
+      { models: "lingo.dev", sourceLocale: "en", aiTimeout: AI_TIMEOUT },
       new Logger({ enableConsole: false }),
     );
 
@@ -47,13 +49,15 @@ describe("the reported failure: a chunk exceeds the 60s API timeout", () => {
       .translate("de", sourceEntries(250))
       .catch((caught: unknown) => caught);
 
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(AI_TIMEOUT);
     const error = await run;
 
     vi.useRealTimers();
 
     expect(error).toBeInstanceOf(PartialTranslationError);
-    expect((error as Error).message).toContain("timed out after 60000ms");
+    expect((error as Error).message).toContain(
+      `timed out after ${AI_TIMEOUT}ms`,
+    );
 
     const partial = (error as PartialTranslationError).partialTranslations;
     expect(Object.keys(partial)).toHaveLength(200);


### PR DESCRIPTION
## Problem

`main` is red. #2190 and #2192 were each green on their own branch and merged cleanly with no textual conflict, but they interact: #2192 raised `DEFAULT_TIMEOUTS.AI_API` from 60000 to 120000, while the repro test added in #2190 advanced fake timers by a literal `60_000` and asserted the message contained `timed out after 60000ms`.

With the new default nothing fires at the 60 second mark, so the test hangs on its own assertion and fails:

```
FAIL  src/translators/lingo/timeout-repro.test.ts > should keep the chunks that finished before the timeout
```

Both release runs failed on it (`32252903262`, `32252920235`), so nothing has published.

## Change

The test now passes its own `aiTimeout` to the translator and derives both the timer advance and the expected message from that one constant. It no longer depends on whatever the package default happens to be, which is what it should have done from the start — the test is about partial results surviving a timeout, not about the default's value.

The default is asserted separately, on purpose, in `translators/ai-timeout-wiring.test.ts`.

Also dropped "60s" from the describe block, which was the same hardcoding in prose.

## Verification

Full package suite on `main` with this change: `19 files, 235 passed, 1 todo`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timeout regression coverage by making the test use an explicit, consistent timeout value.
  - Ensured timeout validation remains reliable even when the package’s default timeout changes.

- **Release**
  - Prepared a patch release for the compiler package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->