### PR TITLE
fix(release): stop publishing deprecated replexica packages

### DIFF
--- a/.changeset/stop-publishing-replexica.md
+++ b/.changeset/stop-publishing-replexica.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stop publishing the deprecated `replexica`, `@replexica/sdk`, and `@replexica/integration-directus` packages. They are marked private so `changeset publish` skips them; all three are already deprecated on npm in favor of `lingo.dev`.

--- a/integrations/directus/package.json
+++ b/integrations/directus/package.json
@@ -2,7 +2,7 @@
   "name": "@replexica/integration-directus",
   "version": "0.1.15",
   "description": "Lingo.dev integration for Directus",
-  "private": false,
+  "private": true,
   "sideEffects": false,
   "directus:extension": {
     "type": "operation",

--- a/legacy/cli/package.json
+++ b/legacy/cli/package.json
@@ -2,7 +2,7 @@
   "name": "replexica",
   "version": "0.71.6",
   "description": "[DEPRECATED] Replexica CLI (now Lingo.dev) - Please use lingo.dev instead",
-  "private": false,
+  "private": true,
   "type": "module",
   "sideEffects": false,
   "types": "build/index.d.ts",

--- a/legacy/sdk/package.json
+++ b/legacy/sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@replexica/sdk",
   "version": "0.7.17",
   "description": "[DEPRECATED] Replexica SDK (now Lingo.dev) - Please use lingo.dev instead",
-  "private": false,
+  "private": true,
   "type": "module",
   "sideEffects": false,
   "types": "index.d.ts",


### PR DESCRIPTION
Every release that reaches the publish step has been failing since 16 July.

## What fails

`changeset publish` succeeds for the `@lingo.dev/*` packages, then exits 1 on three deprecated ones:

```
404 Not Found - PUT https://registry.npmjs.org/replexica
404 Not Found - PUT https://registry.npmjs.org/@replexica%2fsdk
404 Not Found - PUT https://registry.npmjs.org/@replexica%2fintegration-directus
```

Nothing was deleted from npm — all 125 / 28 / 12 published versions are intact. npm answers `404` rather than `403` when a token has no publish rights on a package, so it does not confirm the existence of packages to strangers.

## Cause

`41047ba7` moved the release to Trusted Publishing with OIDC and dropped `NPM_TOKEN`. A trusted publisher is registered per package, and only the `lingo.dev` and `@lingo.dev/*` packages were registered. The `replexica` ones were left on the old auth path, which no longer exists.

The failure is intermittent because `changeset publish` only attempts a package whose local version is ahead of npm. It first appeared on 2026-01-20 when `8c40cb2b` bumped the legacy packages; `662d8ba0` put the version numbers back to what npm held, which silenced it for six months. `a87caafa` bumped them again on 2026-07-16 and the failures resumed — 07-24, 07-28, and three times on 08-19.

## Fix

Mark the three packages private. `changeset publish` filters on that field before it builds its publish list:

```js
const publicPackages = packages.filter(pkg => !pkg.packageJson.private);
```

This holds regardless of how far the version numbers drift, so nobody has to hand-edit them back again. `privatePackages` keeps its defaults (`version: true`, `tag: false`), so the packages still get versioned into changelogs and no longer get git tags.

All three have carried a deprecation notice on npm since January 2025 pointing at `lingo.dev`, and their last real publish was 2025-11-24. Nothing depends on them outside the workspace.

## Verification

- `pnpm install --frozen-lockfile` — clean; `pnpm-lock.yaml` does not record `private`, so the lockfile is untouched
- `pnpm turbo build` for all three packages — 9/9 tasks pass
- no workflow publishes them by any other route
- already-published versions stay installable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deprecated Replexica packages are no longer published to npm.
  * Existing package deprecations remain in place, directing users to lingo.dev.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->