### PR TITLE
fix(compiler): translate JSX passed through attributes (ENG-1368)

### DIFF
--- a/.changeset/jsx-in-props-translated.md
+++ b/.changeset/jsx-in-props-translated.md
@@ -1,0 +1,11 @@
+---
+"@lingo.dev/compiler": patch
+---
+
+Translate JSX handed to a component through an attribute.
+
+`processJSXElement` ends with `path.skip()`, which prunes the whole subtree including `openingElement`. Any JSX inside an attribute expression container — `<FrameHeader actions={<span>Text</span>}>Body</FrameHeader>` — was therefore never visited, so neither its text nor its translatable attributes were extracted. The skip is load-bearing (in the `mixed` branch `rewriteChildren` moves children into arrow functions inside `t()`, and re-traversing would duplicate entries), so the opening element is now traversed with the same visitors immediately before the skip.
+
+User-visible effect: strings that were silently untranslated become new translation entries, so translation volume can jump on the next build.
+
+Not covered, different root causes: prop JSX inside rich/mixed content, where `serializeJSXChildren` only calls `translateAttributes` on the moved element; and arrow render props (`renderCell={() => <span>Cell</span>}`), where `inferComponentName` returns `null` for an arrow whose parent is a `JSXAttribute`.

--- a/.changeset/jsx-in-props-translated.md
+++ b/.changeset/jsx-in-props-translated.md
@@ -2,10 +2,8 @@
 "@lingo.dev/compiler": patch
 ---
 
-Translate JSX handed to a component through an attribute.
+Translate JSX handed to a component through an attribute, such as `actions={<span>Text</span>}`.
 
-`processJSXElement` ends with `path.skip()`, which prunes the whole subtree including `openingElement`. Any JSX inside an attribute expression container — `<FrameHeader actions={<span>Text</span>}>Body</FrameHeader>` — was therefore never visited, so neither its text nor its translatable attributes were extracted. The skip is load-bearing (in the `mixed` branch `rewriteChildren` moves children into arrow functions inside `t()`, and re-traversing would duplicate entries), so the opening element is now traversed with the same visitors immediately before the skip.
+Strings that were silently untranslated become new translation entries, so translation volume can jump on the next build. Translatable attributes inside prop JSX, such as `alt` on an `<img>`, are picked up too.
 
-User-visible effect: strings that were silently untranslated become new translation entries, so translation volume can jump on the next build.
-
-Not covered, different root causes: prop JSX inside rich/mixed content, where `serializeJSXChildren` only calls `translateAttributes` on the moved element; and arrow render props (`renderCell={() => <span>Cell</span>}`), where `inferComponentName` returns `null` for an arrow whose parent is a `JSXAttribute`.
+Still not covered: JSX in a prop of an element that is itself folded into an ancestor's rich text, and JSX returned by an arrow render prop.

--- a/.changeset/jsx-in-props-translated.md
+++ b/.changeset/jsx-in-props-translated.md
@@ -2,8 +2,8 @@
 "@lingo.dev/compiler": patch
 ---
 
-Translate JSX handed to a component through an attribute, such as `actions={<span>Text</span>}`.
+Translate JSX handed to a component through an attribute, such as `actions={<span>Text</span>}` or `renderItem={() => <span>Text</span>}`.
 
-Strings that were silently untranslated become new translation entries, so translation volume can jump on the next build. Translatable attributes inside prop JSX, such as `alt` on an `<img>`, are picked up too.
+Strings that were silently untranslated become new translation entries, so translation volume can jump on the next build. Translatable attributes inside prop JSX, such as `alt` on an `<img>`, are picked up too. A function handed to a prop is treated as the callback it is rather than as a component, so its strings are registered against the enclosing component instead of receiving a translation hook of their own.
 
-Still not covered: JSX in a prop of an element that is itself folded into an ancestor's rich text, and JSX returned by an arrow render prop.
+Still not covered: JSX in a prop of an element that is itself folded into an ancestor's rich text.

--- a/packages/new-compiler/src/plugin/transform/__snapshots__/transform.test.ts.snap
+++ b/packages/new-compiler/src/plugin/transform/__snapshots__/transform.test.ts.snap
@@ -1,5 +1,30 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`transformComponent > JSX passed through attributes > should keep hooks out of a prop callback on a host with no text of its own 1`] = `
+"import { useTranslation } from "@lingo.dev/compiler/react";
+export function Page() {
+  const {
+    t
+  } = useTranslation(["ded0923063da"]);
+  return <FrameHeader actions={function renderIt() {
+    return <span>{t("ded0923063da", "Text A")}</span>;
+  }} />;
+}"
+`;
+
+exports[`transformComponent > JSX passed through attributes > should leave the document root <html> its locale attribute 1`] = `
+"import { useTranslation } from "@lingo.dev/compiler/react";
+export default function Layout({
+  children
+}) {
+  const {
+    t,
+    locale
+  } = useTranslation([]);
+  return <html lang={locale}><body>{children}</body></html>;
+}"
+`;
+
 exports[`transformComponent > JSX passed through attributes > should not inject a hook into a named function passed as a prop 1`] = `
 "import { useTranslation } from "@lingo.dev/compiler/react";
 export function Page() {
@@ -39,6 +64,16 @@ export function Panel() {
     t
   } = useTranslation(["f9b1408ca440", "44b3381ba9de"]);
   return <FrameHeader actions={<span>{t("44b3381ba9de", "Text A")}</span>}>{t("f9b1408ca440", "Text B")}</FrameHeader>;
+}"
+`;
+
+exports[`transformComponent > JSX passed through attributes > should translate JSX returned by an arrow render prop 1`] = `
+"import { useTranslation } from "@lingo.dev/compiler/react";
+export function Page() {
+  const {
+    t
+  } = useTranslation(["20b2cf1823f3"]);
+  return <List renderItem={() => <span>{t("20b2cf1823f3", "Hello world")}</span>} />;
 }"
 `;
 

--- a/packages/new-compiler/src/plugin/transform/__snapshots__/transform.test.ts.snap
+++ b/packages/new-compiler/src/plugin/transform/__snapshots__/transform.test.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`transformComponent > JSX passed through attributes > should not inject a hook into a named function passed as a prop 1`] = `
+"import { useTranslation } from "@lingo.dev/compiler/react";
+export function Page() {
+  const {
+    t
+  } = useTranslation(["94ae71f36192", "f0bda09b5bf3"]);
+  return <FrameHeader actions={function renderIt() {
+    return <span>{t("f0bda09b5bf3", "Text A")}</span>;
+  }}>{t("94ae71f36192", "Text B")}</FrameHeader>;
+}"
+`;
+
+exports[`transformComponent > JSX passed through attributes > should not inject the locale attribute into an <html> inside a prop 1`] = `
+"import { useTranslation } from "@lingo.dev/compiler/react";
+export function Page() {
+  const {
+    t
+  } = useTranslation(["7fd016755b3d", "80d399983384"]);
+  return <FrameHeader actions={<html><body>{t("80d399983384", "Text A")}</body></html>}>{t("7fd016755b3d", "Text B")}</FrameHeader>;
+}"
+`;
+
 exports[`transformComponent > JSX passed through attributes > should register each nested prop JSX exactly once 1`] = `
 "import { useTranslation } from "@lingo.dev/compiler/react";
 export function Nested() {

--- a/packages/new-compiler/src/plugin/transform/__snapshots__/transform.test.ts.snap
+++ b/packages/new-compiler/src/plugin/transform/__snapshots__/transform.test.ts.snap
@@ -1,5 +1,47 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`transformComponent > JSX passed through attributes > should register each nested prop JSX exactly once 1`] = `
+"import { useTranslation } from "@lingo.dev/compiler/react";
+export function Nested() {
+  const {
+    t
+  } = useTranslation(["a8cac695134e", "32acd7466846", "2f5156f6a49b"]);
+  return <Outer header={<Inner badge={<span>{t("2f5156f6a49b", "Deep")}</span>}>{t("32acd7466846", "Middle")}</Inner>}>{t("a8cac695134e", "Shallow")}</Outer>;
+}"
+`;
+
+exports[`transformComponent > JSX passed through attributes > should translate JSX in a prop of an element that also has text children 1`] = `
+"import { useTranslation } from "@lingo.dev/compiler/react";
+export function Panel() {
+  const {
+    t
+  } = useTranslation(["f9b1408ca440", "44b3381ba9de"]);
+  return <FrameHeader actions={<span>{t("44b3381ba9de", "Text A")}</span>}>{t("f9b1408ca440", "Text B")}</FrameHeader>;
+}"
+`;
+
+exports[`transformComponent > JSX passed through attributes > should translate attributes of JSX passed through a prop 1`] = `
+"import { useTranslation } from "@lingo.dev/compiler/react";
+export function Row() {
+  const {
+    t
+  } = useTranslation(["b0deb282e0b3", "4a2587a16bdd"]);
+  return <Cell icon={<img alt={t("4a2587a16bdd", "Company logo")} src="/logo.png" />}>{t("b0deb282e0b3", "Cell label")}</Cell>;
+}"
+`;
+
+exports[`transformComponent > JSX passed through attributes > should translate prop JSX on a rich-text host 1`] = `
+"import { useTranslation } from "@lingo.dev/compiler/react";
+export function Notice() {
+  const {
+    t
+  } = useTranslation(["97be58bd7333", "dff11b9afb69"]);
+  return <Banner action={<a href="/docs">{t("dff11b9afb69", "Read the docs")}</a>}>{t("97be58bd7333", "Hello <b0>world</b0>", {
+      b0: chunks => <b>{chunks}</b>
+    })}</Banner>;
+}"
+`;
+
 exports[`transformComponent > attributes translation > should not translate attributes with expression values 1`] = `
 "import { useTranslation } from "@lingo.dev/compiler/react";
 export function DynamicButton() {

--- a/packages/new-compiler/src/plugin/transform/process-file.ts
+++ b/packages/new-compiler/src/plugin/transform/process-file.ts
@@ -510,11 +510,36 @@ function processJSXElement(
   // handed to this element through an attribute (`actions={<span>Text</span>}`) would
   // never be visited. Traverse the opening element first. Fragments have no attributes.
   if (path.node.type === "JSXElement") {
-    path.get("openingElement").traverse(componentVisitors, { visitorState: state });
+    path.get("openingElement").traverse(attributeVisitors, { visitorState: state });
   }
 
   path.skip();
 }
+
+/**
+ * Visitors for re-entering an element's own attributes. Deliberately narrower than
+ * `componentVisitors`: a function handed to a prop is a callback, not a component, so
+ * hook injection must not reach it — `inferComponentName` accepts any named function
+ * expression, so `actions={function renderIt() { … }}` would otherwise be given a
+ * `useTranslation` call it never runs as a component, breaking the rules of hooks.
+ * `injectHtmlLangAttribute` is left out for the same reason: an `<html>` inside a prop
+ * is not the document root.
+ */
+const attributeVisitors = {
+  JSXFragment(path: NodePath<t.JSXFragment>) {
+    processJSXElement(path, this.visitorState);
+  },
+
+  JSXElement(path: NodePath<t.JSXElement>) {
+    translateAttributes(path.node, this.visitorState);
+
+    if (shouldSkipTranslationForElement(path.node)) {
+      path.skip();
+      return;
+    }
+    processJSXElement(path, this.visitorState);
+  },
+} satisfies TraverseOptions<{ visitorState: VisitorsInternalState }>;
 
 /**
  * Inject dynamic locale attribute into <html> elements

--- a/packages/new-compiler/src/plugin/transform/process-file.ts
+++ b/packages/new-compiler/src/plugin/transform/process-file.ts
@@ -506,6 +506,13 @@ function processJSXElement(
   registerEntry(entry, state, component.name);
   rewriteChildren(path, state, scope, entry.hash);
 
+  // `path.skip()` below prunes the whole subtree, `openingElement` included, so JSX
+  // handed to this element through an attribute (`actions={<span>Text</span>}`) would
+  // never be visited. Traverse the opening element first. Fragments have no attributes.
+  if (path.node.type === "JSXElement") {
+    path.get("openingElement").traverse(componentVisitors, { visitorState: state });
+  }
+
   path.skip();
 }
 

--- a/packages/new-compiler/src/plugin/transform/process-file.ts
+++ b/packages/new-compiler/src/plugin/transform/process-file.ts
@@ -510,36 +510,23 @@ function processJSXElement(
   // handed to this element through an attribute (`actions={<span>Text</span>}`) would
   // never be visited. Traverse the opening element first. Fragments have no attributes.
   if (path.node.type === "JSXElement") {
-    path.get("openingElement").traverse(attributeVisitors, { visitorState: state });
+    path.get("openingElement").traverse(componentVisitors, { visitorState: state });
   }
 
   path.skip();
 }
 
 /**
- * Visitors for re-entering an element's own attributes. Deliberately narrower than
- * `componentVisitors`: a function handed to a prop is a callback, not a component, so
- * hook injection must not reach it — `inferComponentName` accepts any named function
- * expression, so `actions={function renderIt() { … }}` would otherwise be given a
- * `useTranslation` call it never runs as a component, breaking the rules of hooks.
- * `injectHtmlLangAttribute` is left out for the same reason: an `<html>` inside a prop
- * is not the document root.
+ * Is this node part of the value handed to a JSX attribute?
+ *
+ * Two visitors need the answer, and neither can get it from the node alone. A
+ * function sitting in a prop is a callback, not a component — `inferComponentName`
+ * only looks for a name and would happily accept `actions={function renderIt() { … }}`
+ * — and an `<html>` sitting in a prop is not the document root.
  */
-const attributeVisitors = {
-  JSXFragment(path: NodePath<t.JSXFragment>) {
-    processJSXElement(path, this.visitorState);
-  },
-
-  JSXElement(path: NodePath<t.JSXElement>) {
-    translateAttributes(path.node, this.visitorState);
-
-    if (shouldSkipTranslationForElement(path.node)) {
-      path.skip();
-      return;
-    }
-    processJSXElement(path, this.visitorState);
-  },
-} satisfies TraverseOptions<{ visitorState: VisitorsInternalState }>;
+function isInsidePropValue(path: NodePath): boolean {
+  return path.findParent((parent) => parent.isJSXAttribute()) !== null;
+}
 
 /**
  * Inject dynamic locale attribute into <html> elements
@@ -655,6 +642,13 @@ function processComponentFunction(
   >,
   state: VisitorsInternalState,
 ): void {
+  // A function handed to a prop is a callback, however React-shaped it looks. Return
+  // without skipping so its JSX is still reached by the ambient traversal and gets
+  // registered against the enclosing component, whose `t` it closes over. Skipping
+  // here instead would drop those strings, which is what used to happen to arrow
+  // render props.
+  if (isInsidePropValue(path)) return;
+
   if (!isReactComponent(path)) {
     path.skip();
     logger.debug(`Skipping non-React component: ${path.node.type}`);
@@ -714,7 +708,11 @@ const componentVisitors = {
     translateAttributes(path.node, this.visitorState);
 
     // Inject locale attribute into <html> elements for Next.js
-    injectHtmlLangAttribute(path.node, this.visitorState);
+    // Only the document root gets the locale. An `<html>` handed to a prop is
+    // somebody's example markup, not the page.
+    if (!isInsidePropValue(path)) {
+      injectHtmlLangAttribute(path.node, this.visitorState);
+    }
 
     if (shouldSkipTranslationForElement(path.node)) {
       path.skip();

--- a/packages/new-compiler/src/plugin/transform/transform.test.ts
+++ b/packages/new-compiler/src/plugin/transform/transform.test.ts
@@ -3070,6 +3070,13 @@ export default function Layout({ children }) {
       });
 
       expect(result.code).toContain("lang={locale}");
+      // transformComponent injects lang={locale} here, but reports
+      // transformed: false (no translation entries), and both consumers —
+      // next-compiler-loader.ts:41 and unplugin.ts:352 — discard result.code on
+      // that flag, so the attribute never ships. Pre-existing, out of scope
+      // here; this assertion pins today's behavior and will fail when the flag
+      // starts tracking locale-only rewrites.
+      expect(result.transformed).toBe(false);
       expect(result.code).toMatchSnapshot();
     });
   });

--- a/packages/new-compiler/src/plugin/transform/transform.test.ts
+++ b/packages/new-compiler/src/plugin/transform/transform.test.ts
@@ -2852,4 +2852,87 @@ export function Legal() {
       expect(result.code).toMatchSnapshot();
     });
   });
+
+  describe("JSX passed through attributes", () => {
+    it("should translate JSX in a prop of an element that also has text children", () => {
+      const code = `
+export function Panel() {
+  return <FrameHeader actions={<span>Text A</span>}>Text B</FrameHeader>;
+}
+`;
+
+      const result = transformComponent({
+        code,
+        filePath: "src/Panel.tsx",
+        config,
+      });
+
+      expect(result.transformed).toBe(true);
+      assert.isDefined(result.newEntries);
+      expect(result.newEntries.map((e) => e.sourceText).sort()).toEqual(["Text A", "Text B"]);
+      expect(result.code).toMatchSnapshot();
+    });
+
+    it("should translate attributes of JSX passed through a prop", () => {
+      const code = `
+export function Row() {
+  return <Cell icon={<img alt="Company logo" src="/logo.png" />}>Cell label</Cell>;
+}
+`;
+
+      const result = transformComponent({
+        code,
+        filePath: "src/Row.tsx",
+        config,
+      });
+
+      expect(result.transformed).toBe(true);
+      assert.isDefined(result.newEntries);
+      expect(asAttribute(result.newEntries.find((e) => e.type === "attribute")!).sourceText).toBe("Company logo");
+      expect(result.newEntries.map((e) => e.sourceText).sort()).toEqual(["Cell label", "Company logo"]);
+      expect(result.code).toMatchSnapshot();
+    });
+
+    it("should register each nested prop JSX exactly once", () => {
+      const code = `
+export function Nested() {
+  return (
+    <Outer header={<Inner badge={<span>Deep</span>}>Middle</Inner>}>
+      Shallow
+    </Outer>
+  );
+}
+`;
+
+      const result = transformComponent({
+        code,
+        filePath: "src/Nested.tsx",
+        config,
+      });
+
+      expect(result.transformed).toBe(true);
+      assert.isDefined(result.newEntries);
+      expect(result.newEntries.map((e) => e.sourceText).sort()).toEqual(["Deep", "Middle", "Shallow"]);
+      expect(result.code).toMatchSnapshot();
+    });
+
+    it("should translate prop JSX on a rich-text host", () => {
+      const code = `
+export function Notice() {
+  return <Banner action={<a href="/docs">Read the docs</a>}>Hello <b>world</b></Banner>;
+}
+`;
+
+      const result = transformComponent({
+        code,
+        filePath: "src/Notice.tsx",
+        config,
+      });
+
+      expect(result.transformed).toBe(true);
+      assert.isDefined(result.newEntries);
+      expect(result.newEntries.map((e) => e.sourceText)).toContain("Read the docs");
+      expect(result.code).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/new-compiler/src/plugin/transform/transform.test.ts
+++ b/packages/new-compiler/src/plugin/transform/transform.test.ts
@@ -2854,6 +2854,9 @@ export function Legal() {
   });
 
   describe("JSX passed through attributes", () => {
+    // Entry order is deterministic and meaningful: an element's own children are
+    // rewritten first, then its opening element is traversed, so host text comes
+    // before prop JSX and outer elements come before inner ones.
     it("should translate JSX in a prop of an element that also has text children", () => {
       const code = `
 export function Panel() {
@@ -2869,7 +2872,11 @@ export function Panel() {
 
       expect(result.transformed).toBe(true);
       assert.isDefined(result.newEntries);
-      expect(result.newEntries.map((e) => e.sourceText).sort()).toEqual(["Text A", "Text B"]);
+      expect(result.newEntries).toHaveLength(2);
+      expect(result.newEntries.map((e) => e.sourceText)).toEqual([
+        "Text B",
+        "Text A",
+      ]);
       expect(result.code).toMatchSnapshot();
     });
 
@@ -2888,8 +2895,15 @@ export function Row() {
 
       expect(result.transformed).toBe(true);
       assert.isDefined(result.newEntries);
-      expect(asAttribute(result.newEntries.find((e) => e.type === "attribute")!).sourceText).toBe("Company logo");
-      expect(result.newEntries.map((e) => e.sourceText).sort()).toEqual(["Cell label", "Company logo"]);
+      expect(result.newEntries).toHaveLength(2);
+      expect(result.newEntries.map((e) => e.sourceText)).toEqual([
+        "Cell label",
+        "Company logo",
+      ]);
+
+      const altEntry = result.newEntries.find((e) => e.type === "attribute");
+      assert.isDefined(altEntry);
+      expect(asAttribute(altEntry).sourceText).toBe("Company logo");
       expect(result.code).toMatchSnapshot();
     });
 
@@ -2912,7 +2926,12 @@ export function Nested() {
 
       expect(result.transformed).toBe(true);
       assert.isDefined(result.newEntries);
-      expect(result.newEntries.map((e) => e.sourceText).sort()).toEqual(["Deep", "Middle", "Shallow"]);
+      expect(result.newEntries).toHaveLength(3);
+      expect(result.newEntries.map((e) => e.sourceText)).toEqual([
+        "Shallow",
+        "Middle",
+        "Deep",
+      ]);
       expect(result.code).toMatchSnapshot();
     });
 
@@ -2931,7 +2950,64 @@ export function Notice() {
 
       expect(result.transformed).toBe(true);
       assert.isDefined(result.newEntries);
-      expect(result.newEntries.map((e) => e.sourceText)).toContain("Read the docs");
+      expect(result.newEntries).toHaveLength(2);
+      expect(result.newEntries.map((e) => e.sourceText)).toEqual([
+        "Hello <b0>world</b0>",
+        "Read the docs",
+      ]);
+      expect(result.code).toMatchSnapshot();
+    });
+
+    // `inferComponentName` accepts any named function expression, so running the
+    // full component visitors here would treat a callback handed to a prop as a
+    // component and give it a `useTranslation` call it never runs as one — a
+    // rules-of-hooks violation. The narrowed set still translates the callback's
+    // JSX; `t` resolves through the closure over the enclosing component.
+    it("should not inject a hook into a named function passed as a prop", () => {
+      const code = `
+export function Page() {
+  return <FrameHeader actions={function renderIt() { return <span>Text A</span>; }}>Text B</FrameHeader>;
+}
+`;
+
+      const result = transformComponent({
+        code,
+        filePath: "src/Page.tsx",
+        config,
+      });
+
+      expect(result.transformed).toBe(true);
+      assert.isDefined(result.newEntries);
+      expect(result.newEntries.map((e) => e.sourceText)).toEqual([
+        "Text B",
+        "Text A",
+      ]);
+      // Once for the import, once for the single call in `Page` — none inside
+      // `renderIt`.
+      expect(result.code.match(/useTranslation/g)).toHaveLength(2);
+      expect(result.code).toMatchSnapshot();
+    });
+
+    it("should not inject the locale attribute into an <html> inside a prop", () => {
+      const code = `
+export function Page() {
+  return <FrameHeader actions={<html><body>Text A</body></html>}>Text B</FrameHeader>;
+}
+`;
+
+      const result = transformComponent({
+        code,
+        filePath: "src/PageHtml.tsx",
+        config,
+      });
+
+      expect(result.transformed).toBe(true);
+      assert.isDefined(result.newEntries);
+      expect(result.newEntries.map((e) => e.sourceText)).toEqual([
+        "Text B",
+        "Text A",
+      ]);
+      expect(result.code).not.toContain("lang={locale}");
       expect(result.code).toMatchSnapshot();
     });
   });

--- a/packages/new-compiler/src/plugin/transform/transform.test.ts
+++ b/packages/new-compiler/src/plugin/transform/transform.test.ts
@@ -2958,11 +2958,11 @@ export function Notice() {
       expect(result.code).toMatchSnapshot();
     });
 
-    // `inferComponentName` accepts any named function expression, so running the
-    // full component visitors here would treat a callback handed to a prop as a
-    // component and give it a `useTranslation` call it never runs as one — a
-    // rules-of-hooks violation. The narrowed set still translates the callback's
-    // JSX; `t` resolves through the closure over the enclosing component.
+    // `inferComponentName` accepts any named function expression, so a callback
+    // handed to a prop would otherwise be treated as a component and given a
+    // `useTranslation` call it never runs as one — a rules-of-hooks violation. Its
+    // JSX is still translated and registered against the enclosing component,
+    // whose `t` it closes over.
     it("should not inject a hook into a named function passed as a prop", () => {
       const code = `
 export function Page() {
@@ -3008,6 +3008,68 @@ export function Page() {
         "Text A",
       ]);
       expect(result.code).not.toContain("lang={locale}");
+      expect(result.code).toMatchSnapshot();
+    });
+
+    // A host with nothing translatable of its own never reaches
+    // `processJSXElement`'s trailing `path.skip()`, so the ambient traversal walks
+    // into its attributes on its own. The guard has to hold on that path too — a
+    // self-closing element carrying only a callback prop is the common shape.
+    it("should keep hooks out of a prop callback on a host with no text of its own", () => {
+      const code = `
+export function Page() {
+  return <FrameHeader actions={function renderIt() { return <span>Text A</span>; }} />;
+}
+`;
+
+      const result = transformComponent({
+        code,
+        filePath: "src/SelfClosing.tsx",
+        config,
+      });
+
+      expect(result.transformed).toBe(true);
+      assert.isDefined(result.newEntries);
+      expect(result.newEntries.map((e) => e.sourceText)).toEqual(["Text A"]);
+      expect(asContent(result.newEntries[0]).context.componentName).toBe("Page");
+      expect(result.code.match(/useTranslation\(/g)).toHaveLength(1);
+      expect(result.code).toMatchSnapshot();
+    });
+
+    it("should translate JSX returned by an arrow render prop", () => {
+      const code = `
+export function Page() {
+  return <List renderItem={() => <span>Hello world</span>} />;
+}
+`;
+
+      const result = transformComponent({
+        code,
+        filePath: "src/RenderProp.tsx",
+        config,
+      });
+
+      expect(result.transformed).toBe(true);
+      assert.isDefined(result.newEntries);
+      expect(result.newEntries.map((e) => e.sourceText)).toEqual(["Hello world"]);
+      expect(asContent(result.newEntries[0]).context.componentName).toBe("Page");
+      expect(result.code).toMatchSnapshot();
+    });
+
+    it("should leave the document root <html> its locale attribute", () => {
+      const code = `
+export default function Layout({ children }) {
+  return <html><body>{children}</body></html>;
+}
+`;
+
+      const result = transformComponent({
+        code,
+        filePath: "src/Layout.tsx",
+        config,
+      });
+
+      expect(result.code).toContain("lang={locale}");
       expect(result.code).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
Closes ENG-1368.

## Problem

`processJSXElement` ends with `path.skip()` (`packages/new-compiler/src/plugin/transform/process-file.ts`), which prunes the entire subtree — `openingElement` included. JSX handed to a component through an attribute was therefore never visited:

```jsx
<FrameHeader actions={<span>Text A</span>}>Text B</FrameHeader>
```

Before: `["Text B"]` — `Text A` silently untranslated.
After: `["Text A", "Text B"]`.

The skip only fires when the element had translatable text children, which is why the bug looks intermittent: the same prop JSX extracts fine on an element whose children are not directly translatable.

Broader than the original report — translatable **attributes** inside prop JSX (`alt` on an `<img>`) were lost too, and rich-text hosts (`Hello <b>world</b>`) are affected.

## Fix

The skip is load-bearing: in the `mixed` branch `rewriteChildren` moves children into arrow functions inside `t()`, so re-traversing would duplicate entries. Deleting it is not an option. Instead the opening element is traversed with the same visitors immediately before the skip, guarded on `JSXElement` because the function also serves `JSXFragment` (which has no attributes).

Plain attributes are unaffected — `componentVisitors` has no `JSXAttribute` visitor, so only nested JSX and functions inside attribute expressions get picked up.

## Verification

- `239 passed | 1 todo (240)` in `packages/new-compiler`, `tsc --noEmit` clean.
- **Zero changes to existing snapshots** — the four new snapshots are the only additions.
- The four new tests were confirmed to fail with the source change stashed and the tests in place (`expected [ 'Text B' ] to deeply equal [ 'Text A', 'Text B' ]`), so they genuinely cover the regression. There was no test for JSX-in-props before.

## Not covered

Left out deliberately, different root causes:

- prop JSX inside rich/mixed content — `serializeJSXChildren` only calls `translateAttributes` on the moved element
- arrow render props (`renderCell={() => <span>Cell</span>}`) — `inferComponentName` returns `null` for an arrow whose parent is a `JSXAttribute`

## Note for the release

The changeset calls this out: strings that were silently untranslated become new translation entries, so translation volume can jump on the next build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation extraction for JSX nested within component properties, including nested text, translatable attributes, deeply nested JSX, and rich-text elements.
  * Added support for JSX in callback and arrow render props.
  * Prevented duplicate translation entries while preserving deterministic ordering and existing mixed-content behavior.
  * Avoided incorrect locale attributes and hook injection in JSX callback properties, including document-root elements.

* **Tests**
  * Added coverage for callback render props, extracted text and attributes, entry counts, ordering, and transformed output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->